### PR TITLE
Onboarding for people with and without API access, plus the API contracts

### DIFF
--- a/.env.skills.example
+++ b/.env.skills.example
@@ -1,0 +1,104 @@
+# SiftStack skill library, credentials
+#
+# Copy to .env and fill in ONLY what you want. Everything here is optional.
+# Nine skills need nothing at all from this file.
+#
+#   cp .env.skills.example .env
+#   python3 install.py --doctor
+#
+# Every skill degrades rather than failing. A missing key means that step is
+# skipped and the run says so. Nothing hard-fails because you did not sign up
+# for something.
+#
+# Contracts and gotchas for each service: docs/api/
+# What to do instead of paying:           docs/setup/no-api-playbook.md
+# (This file is for the SKILL LIBRARY. The full platform has more; see
+#  .env.example.)
+
+
+# ---------------------------------------------------------------------------
+# Your DataSift login
+# ---------------------------------------------------------------------------
+# Powers sift-market-research, sequential-presets, sift-sequences, kpi-engine.
+# These drive the web app in a browser, so this is your normal login and NOT
+# an API key. Works on any plan.
+DATASIFT_EMAIL=
+DATASIFT_PASSWORD=
+
+# kpi-engine mints its own token from the login above. Set this only if you
+# want to supply one yourself. Tokens expire in about 48 hours; the login does
+# not, which is why minting is the default.
+REISIFT_TOKEN=
+
+
+# ---------------------------------------------------------------------------
+# Comping and deal analysis
+# ---------------------------------------------------------------------------
+# comp-package, deal-analyzer. 100 lookups per month free.
+# Without it, the real-estate-comping skill does the same job by browser.
+# Note: one property comped properly is several lookups, not one.
+# https://openwebninja.com
+OPENWEBNINJA_API_KEY=
+
+
+# ---------------------------------------------------------------------------
+# Phone scoring
+# ---------------------------------------------------------------------------
+# phone-validator, and the scoring pass at the end of every skip trace.
+# About $0.015 per number. Dialing in tier order is worth about 4.75x the
+# connect rate, which is the whole argument for it.
+# https://trestleiq.com
+TRESTLE_API_KEY=
+
+
+# ---------------------------------------------------------------------------
+# Deep prospecting (heir research)
+# ---------------------------------------------------------------------------
+# deep-prospecting-v5. About $0.24 per record end to end.
+# SmartSkip returns relatives AND their phones in one batch.
+# https://smartskip.com
+SMARTSKIP_EMAIL=
+SMARTSKIP_PASSWORD=
+
+# Cheap gap fill for relatives SmartSkip named but left phoneless (about 7%).
+# https://tracerfy.com
+TRACERFY_API_KEY=
+
+# Enformion is OPTIONAL and only needed for LLC and trust owners. Do not use it
+# for the relatives graph: it returned zero relatives on 6 of 12 test owners and
+# carries no phone numbers.
+# https://enformion.com
+ENFORMION_AP_NAME=
+ENFORMION_AP_PASSWORD=
+
+
+# ---------------------------------------------------------------------------
+# Call coaching
+# ---------------------------------------------------------------------------
+# cold-call-coach, lead-manager-coach, closer-coach.
+# Recordings come from your dialer session. This key is for transcription,
+# about $0.002 per audio minute.
+OPENROUTER_API_KEY=
+
+# Or transcribe and reason with Anthropic directly.
+ANTHROPIC_API_KEY=
+
+
+# ---------------------------------------------------------------------------
+# Caller reputation
+# ---------------------------------------------------------------------------
+# caller-reputation-monitor. Keeps outbound numbers out of "Spam Likely".
+# Included with a Telnyx account.
+TELNYX_API_KEY=
+TELNYX_ENTERPRISE_ID=
+
+
+# ---------------------------------------------------------------------------
+# Optional extras
+# ---------------------------------------------------------------------------
+# Address standardization and vacancy. 250 free lookups per month.
+SMARTY_AUTH_ID=
+SMARTY_AUTH_TOKEN=
+
+# Run summaries and alerts to Slack or Discord.
+SLACK_WEBHOOK_URL=

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -93,6 +93,21 @@ jobs:
             echo "::error::second install was not a no-op; installer is not idempotent"; exit 1; }
           echo "installer OK, $(find /tmp/skills-ci -maxdepth 1 -mindepth 1 -type d | wc -l) packages"
 
+      - name: Setup docs match the manifest
+        # The doctor tells people "use X instead". If X points at a section
+        # that does not exist, they are stranded at the moment they asked for
+        # help. Also fails if a documented env var is missing from the example
+        # file, or if the example file ever carries a real value.
+        run: python tools/check_docs.py --ci
+
+      - name: Doctor runs clean with no credentials at all
+        # The first thing a new person runs. It must not need anything.
+        run: |
+          env -u DATASIFT_EMAIL -u DATASIFT_PASSWORD -u OPENWEBNINJA_API_KEY               -u TRESTLE_API_KEY python install.py --doctor > /tmp/doc.txt
+          grep -q "Works right now" /tmp/doc.txt
+          grep -q "Needs a credential" /tmp/doc.txt
+          echo "doctor OK"
+
       - name: No credentials in anything we distribute
         run: |
           python - <<'PY'

--- a/README.md
+++ b/README.md
@@ -120,14 +120,30 @@ Two superseded packages (`deep-prospecting`, `deep-prospecting-v4`) stay in the 
 
 ### What a skill needs from you
 
-Most skills call a paid API and read the key from your own environment. They degrade rather than fail: a missing key means that step is skipped and the run says so.
+**Nine of the 22 work the moment they are installed.** No key, no login, no card. Ask the library where you stand:
 
-| Skill group | Wants | Roughly |
+```bash
+python3 install.py --doctor
+```
+
+It reads your environment and a `.env` if you have one, then prints what works now, what needs you signed in somewhere, and what needs a credential. Every blocked skill prints its no-API alternative on the same line, so you are never told no without being told what to do instead. It sends no requests, spends nothing, and never prints a credential value.
+
+| Tier | Count | What it means |
 |---|---|---|
-| Comping, deal analysis | `OPENWEBNINJA_API_KEY` | 100 free lookups/month |
-| Deep prospecting | SmartSkip, Tracerfy, Trestle | about $0.24 per record end to end |
-| Phone validation | `TRESTLE_API_KEY` | $0.015 per number |
-| Coaching, KPI | Your SmrtPhone and DataSift logins | included in those plans |
+| No credentials | 9 | Works on install |
+| A login you already have | 8 | DataSift, SmrtPhone, Google. Browser-driven, no API access needed |
+| A metered API key | 5 | Faster and deeper, and every one has a free route |
+
+**Every paid step has a no-API route.** Comping runs by browser, heir research runs off obituaries and free people-search, KPIs run off a CSV export, coaching runs off any dialer's recordings. The [no-API playbook](docs/setup/no-api-playbook.md) has the method for each, and is honest about the three things that have no substitute.
+
+Skills degrade rather than fail: a missing key means that step is skipped and the run says so.
+
+| Guide | |
+|---|---|
+| [**Getting started**](docs/setup/GETTING-STARTED.md) | Install, check readiness, add credentials, first runs |
+| [**No-API playbook**](docs/setup/no-api-playbook.md) | The free route for every paid step |
+| [**API contracts**](docs/api/) | What each API actually does, and the traps that cost real time |
+| [`.env.skills.example`](.env.skills.example) | Every variable, what it unlocks, what it costs |
 
 ---
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,56 @@
+# API contracts
+
+What each API actually does, as opposed to what its documentation says.
+
+Every file here records a contract that was verified against the live service,
+plus the traps that cost real time to find. Most of these are not in any
+vendor doc, and several are things the vendor doc states incorrectly.
+
+Read the file before writing code against a service. It is faster than
+rediscovering the same trap.
+
+## Why this exists
+
+Three failure patterns show up repeatedly across these providers, and they are
+worth recognising as a class:
+
+1. **The silent parameter.** You pass a filter, the API accepts the request,
+   returns 200, and ignores the filter. Nothing tells you. The fix is always
+   the same: read back the echoed parameters in the response and assert your
+   filter actually applied.
+2. **The empty success.** You are out of credit, or unlicensed for that search
+   type, or the record does not exist, and the response is a 200 with an empty
+   array. A run that succeeds with no data is worse than one that fails.
+3. **The moved contract.** An endpoint is retired, or the gate changes from one
+   provider to another, and the old call keeps returning something plausible.
+   Every solve gets billed and discarded.
+
+Where a file records a specific instance of one of these, it says so.
+
+## The files
+
+| File | Covers | Used by |
+|---|---|---|
+| [openwebninja-zillow.md](openwebninja-zillow.md) | Property search, sold comps, listing data | `comp-package`, `deal-analyzer` |
+| [trestle.md](trestle.md) | Phone intelligence and scoring | `phone-validator` |
+| [skip-trace.md](skip-trace.md) | SmartSkip, Tracerfy, Enformion | `deep-prospecting-v5` |
+| [datasift.md](datasift.md) | DataSift / REISift, both API surfaces | `kpi-engine`, uploads, the CRM stack |
+| [smrtphone.md](smrtphone.md) | SMS send, call logs, recordings, webhooks | the coach skills, the SMS agent |
+| [county-data.md](county-data.md) | Assessor, recorder and court portals | `first-market-county-data`, `probate-property-finder` |
+| [scraping-infra.md](scraping-infra.md) | Scrapfly, Apify proxy, 2Captcha, Turnstile | the acquisition pipeline |
+
+## Conventions
+
+- **No credentials anywhere.** Every example uses a placeholder. If you find a
+  real key in this directory, that is a bug, and CI is supposed to catch it.
+- **Verified means verified.** A line that says "verified" was run against the
+  live service on the stated date. Anything inferred says so.
+- **Costs are what we were actually billed**, not list price. Where a rate is
+  an affiliate or negotiated rate, it says which.
+
+## If a contract has moved
+
+These services change. When a call in here stops matching reality, fix the file
+in the same commit as the code, and record what the old behaviour was. The
+history of a contract is often more useful than its current state, because it
+tells you what kind of change this vendor makes.

--- a/docs/api/county-data.md
+++ b/docs/api/county-data.md
@@ -1,0 +1,117 @@
+# County data portals
+
+The free layer, and the most valuable one. Assessor, recorder and court data is
+public, and in most counties it is machine readable if you look past the search
+page someone built on top of it.
+
+- **Used by:** `first-market-county-data`, `probate-property-finder`,
+  `buyer-prospector`
+- **Cost:** free, everywhere in this file
+
+## The general method
+
+Every one of these was found the same way, and it works on portals not listed
+here:
+
+1. **Open the portal's own search in a browser with devtools open.** Run the
+   search you want by hand.
+2. **Watch the network tab.** The page is almost always calling a JSON endpoint
+   that you can call directly.
+3. **Replay that request.** Copy as cURL, strip it down to what actually
+   matters.
+
+The search UI is the thing that blocks you. The endpoint underneath usually
+does not.
+
+## The four traps, in order of how much time they cost
+
+### 1. The empty table shell
+
+TPAD (Blount County TN) serves an HTML page whose results table is **an empty
+shell**. Its id is `searchResultsTable`, not the `resultsTable` a parser might
+guess, and either way it contains no rows.
+
+The rows come from `POST /TPAD/Search/GetSearchResults`, which returns clean
+JSON.
+
+Scraping the page returns zero rows, silently, forever. Every downstream lookup
+fails, the address stays empty, and validation later drops the record as
+"missing address". Nothing anywhere says the parser is looking at the wrong
+thing. A Blount probate backfill would have produced about 950 records and zero
+usable ones.
+
+### 2. The User-Agent wall
+
+TPAD **403s anything without a browser User-Agent**. Bare `requests` gets
+nothing. One header fixes it.
+
+Worth trying first on any portal that returns 403 to code and 200 to a browser.
+
+### 3. The house number comes last
+
+TPAD prints addresses as `"LAKESHORE DR  5705"`.
+
+That fails validation and fails address standardization, so it looks like bad
+data rather than a formatting convention. Normalize to `5705 Lakeshore Dr`
+before anything downstream sees it.
+
+### 4. The stale path with the fresh file
+
+Franklin County OH publishes owner rolls on an open file server. The **folder
+path is stale on purpose**: the newest-looking folder said `2025/07` while the
+file inside it had a Last-Modified three days old.
+
+**Check the header, not the path.** And the newer-looking "Outside_User_Files"
+tab-delimited appraisal extract has **no owner fields at all**, only values and
+situs, so it looks like an upgrade and is useless for this.
+
+## Result caps
+
+Portals truncate, usually without telling you.
+
+The TN public notice site caps **every** result set at 20 pages / 1000 rows,
+newest first. A plain 12-month search silently loses its tail, and two of four
+searches sat exactly on that ceiling.
+
+**If a result count is suspiciously round, it is a cap.** Chunk the query, by
+month or by price band, until each chunk comes back under the ceiling.
+
+## Records that are not online at all
+
+Some counties genuinely do not publish. Knox County TN estate and probate case
+files are not online, and deed images sit behind a paid subscription.
+
+That is a phone call or a visit, not a scraping problem, and recognising it
+early saves a day. `first-market-county-data` tells you which is which for your
+county, and carries FOIA request templates for the rest.
+
+## Name-based joins
+
+Liens and judgments are indexed **against the person**, not the parcel. Zero
+percent of lien rows carry a parcel id.
+
+The join is debtor name to the county tax API. Measured hit rate on a full run:
+**40 percent**. A 500-name sample read 64 percent only because it was sorted by
+lien count, which put the most active debtors first. Beware sorted samples.
+
+**Release filtering is not optional.** Against 12 months of liens there were
+27,493 release documents. **8 percent of lead debtors had every lien already
+satisfied** and were dead leads. Compute active as recorded minus released, and
+match at instrument level: a name-only match tells you that person had
+something released, not that this lien was.
+
+## Open ArcGIS layers
+
+Several counties publish parcels with owner fields as ArcGIS feature services,
+queryable with no key. Licking County OH serves 100,000 rows per call and
+inlines the last three transfers.
+
+Ohio's statewide OGRIP layer **strips owner fields** from the public view, so
+county-level layers are the ones worth finding.
+
+Six Columbus-metro counties came to **811,146 owner rows for $0**.
+
+## Vendor search UIs
+
+Schneider Beacon, DEVNET Pivot and similar are bot-walled and, in every case we
+hit, unnecessary. The county publishes the same data elsewhere.

--- a/docs/api/datasift.md
+++ b/docs/api/datasift.md
@@ -1,0 +1,131 @@
+# DataSift (REISift)
+
+The CRM everything lands in. It has **two API surfaces with different powers**,
+and picking the wrong one is the single most common blocker here.
+
+- **Domain:** `app.reisift.io`. API at `apiv2.reisift.io`. Not `app.datasift.ai`
+- **Used by:** `kpi-engine`, `sequential-presets`, `sift-sequences`,
+  `sift-market-research`, the upload stack
+
+## Which credential can do what
+
+| | Open API key | User JWT |
+|---|---|---|
+| Read properties, lists, tags | yes | yes |
+| Write properties, upsert | yes | yes |
+| **Custom fields** | **no, they do not exist in its 93 routes** | yes |
+| Activity log for KPIs | limited | yes |
+| Expiry | never | about 48 hours |
+
+**If you need custom fields, you need the minted JWT.** The Open API key
+returns 401 on every custom-field write, and the routes are not merely
+forbidden, they are absent from its surface entirely. That distinction matters
+because a 404 reads like a wrong URL rather than a permissions problem.
+
+### Mint the JWT, never paste one
+
+```
+POST /api/token/
+  {"email": "...", "password": "..."}
+  -> {"access": "...", "refresh": "..."}
+```
+
+Mint from credentials at start of run and **re-mint every 30 minutes**. A long
+upload that pastes a token dies partway through when it expires, usually after
+it has already written half the records.
+
+This is also why `kpi-engine` needs no special access: it mints from your own
+login like any other user.
+
+## Upload contract, and four traps that fail quietly
+
+`POST /property/` is **upsert by address**, so re-runs never duplicate. Lists
+**accumulate** rather than replace: a record came back carrying both new lists
+plus four it already had.
+
+### 1. Tags must be an array
+
+A comma string does not split. It creates one tag literally named
+`"Courthouse Data, code_violation, Knox"`.
+
+```json
+"tags": ["Courthouse Data", "code_violation", "Knox"]
+```
+
+### 2. A select field's value is the option's UUID, not its label
+
+```
+"LEN"  ->  {"non_field_errors": ["'LEN' is not a valid UUID."]}
+```
+
+Resolve the label to its UUID from `custom-fields/` `options[]` first. Creating
+a `select` custom field **requires its options in the same POST**; you cannot
+add them afterwards.
+
+### 3. An entity owner cannot have a blank first_name
+
+The API rejects `""`. Send the business as `company` and **omit** the person
+keys entirely. Omitting a key is not the same as sending an empty string, and
+this is the difference between a 200 and a 400.
+
+### 4. `notes` on the property payload returns 200 and is discarded
+
+It looks like it worked. It did not. Post notes separately.
+
+### Custom field writes
+
+```
+PATCH /api/internal/property/{uuid}/custom-field/update-values/
+  [{"field_uuid": "...", "value": "..."}]
+```
+
+## The habit that catches all four
+
+**Upload one record and read it back before releasing the file.**
+
+That single habit caught the tag format, the entity rejection, the option-UUID
+requirement, and a list-name mismatch that would have silently attached nothing
+for 2,512 of 2,573 records. Every one of those returns a success status.
+
+## Rate limiting on /api/internal
+
+It throttles hard. Six threads at about 7 requests per second **429'd 529 of
+740 records**. Single-threaded at about 2 per second, with backoff that reads
+the server's "available in N seconds" hint, completed cleanly.
+
+Make long pulls resumable and checkpoint every 25 records. You will hit this.
+
+## Reading numbers off records
+
+Field names on a record are **not** the CSV upload column names. Verified live:
+
+```
+estimate_value, equity_percent, last_sold, last_sale_price, rental_value,
+sqft, bedrooms, bathrooms, year, lot_size, parcel_id, apn, investor_score,
+structure_type, assigned_to, address{...}, owner{...}
+```
+
+`assigned_to` is a bare uuid, not an object. County and coordinates live on
+`address`. Mailing address lives on `owner.address`.
+
+**`Total Delinquency` is liens plus taxes.** One record reads 13,766.72 =
+12,908.72 lien + 858.00 tax. Reading it as the tax figure double counts the
+lien and inflates exactly the records a distress model is built to surface. Tax
+amount comes from `Tax delinquency amount` or native `tax_delinquent_value`,
+never from Total Delinquency.
+
+## Status reads
+
+`GET` property status needs `limit=1000` or you get a truncated page that looks
+like a complete answer. The count index lags behind writes, so do not verify a
+write by checking a count.
+
+## No REST API for the UI work
+
+Presets, sequences and SiftMap have no API. Those skills drive the web app with
+Playwright, which is why they need your login rather than a key.
+
+If you would rather not automate, [build them by
+hand](../setup/no-api-playbook.md#presets-by-hand): the skills carry all 21
+preset and 26 sequence definitions as data, and the definition is the valuable
+part.

--- a/docs/api/openwebninja-zillow.md
+++ b/docs/api/openwebninja-zillow.md
@@ -1,0 +1,89 @@
+# OpenWeb Ninja, Zillow property data
+
+Sold comps, active listings and property detail. The comping stack runs on it.
+
+- **Key:** `OPENWEBNINJA_API_KEY`
+- **Cost:** 100 lookups per month free, metered after
+- **Used by:** `comp-package`, `deal-analyzer`, `src/zillow_market_api.py`
+- **Verified:** 2026-07-21, re-checked 2026-08
+
+## The endpoint moved, and the old one still looks alive
+
+`similar-sale-homes`, and every other comps-shaped endpoint, is **retired and
+404s**. If you are reading an older integration that calls it, that code has
+been dead since the change.
+
+**`/search` is the workhorse.** Everything comping-related goes through it.
+
+`property-details-address` is still live and is a different thing: single
+property detail by address, not comps. `src/property_enricher.py` uses it.
+
+## The contract
+
+```
+GET /search
+  location      "Knoxville, TN" or a ZIP
+  home_status   RECENTLY_SOLD | FOR_SALE      <- exact enum, see below
+  min_price     integer
+  max_price     integer
+  page          integer
+```
+
+### home_status is an exact enum
+
+`RECENTLY_SOLD` and `FOR_SALE`, spelled exactly. Anything else returns 400.
+Not `recently_sold`, not `SOLD`, not `Recently Sold`.
+
+### Every search caps at 41 rows
+
+`totalPages` comes back as 1 no matter how many results exist. In an active ZIP
+that is roughly five weeks of sales, which is nowhere near enough for a comp
+set and is very easy to mistake for "this market is quiet".
+
+**The workaround is price-band partitioning.** Split the search by
+`min_price`/`max_price` into bands, and recursively split any band that comes
+back saturated at 41. `pull_sold()` in `src/zillow_market_api.py` implements
+it. Expect 50 to 80 calls to recover 2 to 3 years for one ZIP.
+
+### price_min and price_max are silently ignored
+
+This is the classic silent parameter. The names are `min_price` and
+`max_price`. Pass `price_min` and the request succeeds, returns 200, and the
+filter does nothing, so you get an unfiltered 41-row window and no indication
+anything is wrong.
+
+**Always read back the echoed `parameters` object** in the response and assert
+your filter actually applied. Do this for every filter, not just price.
+
+### Field traps
+
+| Field | Trap |
+|---|---|
+| `dateSold` | Epoch milliseconds, not seconds and not a date string |
+| `soldPrice` | A display string like `"$132,000"`. Use `unformattedPrice` for math |
+| `homeType: LOT` | Ambiguous. Either a house that sold at land value, or a new build with sqft missing. Check the county card before bucketing it |
+| `livingArea` | Frequently absent on older records. Missing, not zero |
+| `bedrooms` | Aggregators get this wrong often enough that a county card always wins |
+
+## What it will never show you
+
+MLS-only data. Auction sales, wholesale assignments and off-market transfers do
+not appear at all.
+
+For those, county records are the only truth, and that is not a limitation you
+can work around inside this API. If a property traded and this API has no
+record, that absence is itself a signal worth noticing.
+
+## Cost control
+
+- One property comped properly is several calls, not one. The 100 free lookups
+  go faster than the number suggests.
+- Cache the band pull. `comp_package.py --sold-json` re-runs off a saved pull
+  and costs nothing, which matters because you will re-run.
+- Partition by price, not by date. Date filtering is not reliable enough to
+  bound the set.
+
+## Without the key
+
+Use the `real-estate-comping` skill: the same method with comps gathered by
+browser. See [the no-API playbook](../setup/no-api-playbook.md#comping-without-an-api).

--- a/docs/api/scraping-infra.md
+++ b/docs/api/scraping-infra.md
@@ -1,0 +1,145 @@
+# Scraping infrastructure: proxies, gates, browsers
+
+Only relevant if you run the acquisition pipeline. None of the skills need any
+of this.
+
+The through-line: **most scraping failures are not code failures.** Before
+debugging a parser, prove you can reach the page at all from where you are.
+
+## Diagnose egress before anything else
+
+A site can decide, per IP, that it will not serve you, and it does not have to
+say so in a way that looks like blocking.
+
+Verified live against one site, same login, same code, three networks:
+
+| From | What the page did |
+|---|---|
+| Office IP | **No challenge at all.** Just "You are not permitted to view public notices from this computer at this time" |
+| Datacenter proxy | Normal challenge, then the content |
+| Residential proxy | Served with no gate |
+
+The office case is the dangerous one: no challenge, no error, no HTTP failure.
+It reads as a solver bug and it is a network problem.
+
+**Treat a blocked run as its own outcome.** Ours exits `3` rather than `1`,
+because no retry fixes it and a generic failure sends you into the parser.
+
+### Volume matters as much as address
+
+One month of scraping through a single sticky session viewed about **204
+notices** before that IP began refusing, and every later job then failed in
+about 60 seconds against the same dead address.
+
+Two things fix it, and both are load-bearing:
+- rotate the session id **per process**, not per run
+- split the work so no single session exceeds the threshold
+
+Then accept that some jobs still hit a burned IP. A retry pass with a fresh
+address converges. Do not retry in a tight loop: the pool is small and
+addresses need to cool.
+
+## Apify proxy
+
+Resolution order that works: explicit proxy URL, then Apify groups looked up
+with the API token, then direct.
+
+### The 407 that looks like bad credentials
+
+**Apify session ids accept only letters, digits, underscore and dot.**
+
+`session-tnpn-fly` returns `407 Proxy Authentication Required`. `tnpn_fly`,
+`tnpnfly`, `tnpn.fly` and `tnpn` all return 200, on the same credentials.
+
+A hyphen in a session name is indistinguishable from a rejected password in the
+error. Sanitize the session id and log the substitution.
+
+Also: the API token is **not** the proxy password. It is used to look the
+password up.
+
+### Group availability is per plan
+
+`RESIDENTIAL` reported `availableCount: 0` on our plan. A datacenter group with
+27 US addresses worked. Check availability before assuming a group exists.
+
+## Cloudflare Turnstile
+
+The gate changed from reCAPTCHA to Turnstile on 2026-07-13, and this is the
+clearest instance of a moved contract in the whole system.
+
+The config recorded the migration. The solver did not: it still called the
+reCAPTCHA method and injected into `g-recaptcha-response`, a field the page no
+longer reads. **Every solve was billed and discarded**, and the failure looked
+like a flaky gate rather than a wrong integration.
+
+What the working version does:
+
+- selects both the solve method and the response field from one config value,
+  so they cannot drift apart
+- reads the **sitekey off the live page**, and logs `SITEKEY ROTATED` rather
+  than dying quietly when it changes
+- **creates the `cf-turnstile-response` input** when the headless widget never
+  renders one
+- runs the blocking solve **in a thread**, so the browser event loop keeps
+  servicing the page while waiting
+
+**The gate is session level.** One solve covers the rest of the run, which
+changes the cost model completely: budget per run, not per page.
+
+## Scrapfly
+
+Residential proxy, anti-bot and rendering in one call. `asp=True` plus
+`render_js=True` clears most JS walls.
+
+### The trap: a fresh session per scrape
+
+Every Scrapfly scrape gets a **new cookieless ASP.NET session**. So a direct
+detail-page fetch lands in a session that never ran a search, and the server
+returns an unpopulated shell.
+
+The result is `gate_not_cleared` on every page, taking about three minutes
+each, before falling back. It looks like the gate beating you. It is not.
+
+**The fix is to do the whole walk inside one call**: search, then navigate to
+the record, in a single scenario. That works and returns real content with no
+gate from a residential address.
+
+### Where it is worth it
+
+County records, assessor datalets, genealogy and court pages that block plain
+fetches. Hardened people-search aggregators frequently IP-ban it outright, so
+do not plan around those.
+
+## Browser automation
+
+Some sites need a real browser and there is no way around it. ASP.NET WebForms
+is the clearest case: navigation is `__doPostBack` with ViewState, so an HTTP
+client has to hand-manage ViewState and EventValidation for every click.
+
+Two practical notes that cost real time:
+
+- **Wait on `domcontentloaded`, not `networkidle`.** Through a proxy,
+  networkidle regularly never settles, and it abandoned a working search after
+  30 seconds.
+- **Pin the browser image to the client version.** A mismatch fails in ways
+  that look like site changes.
+
+## Persist state only after success
+
+Ordering, not code, is the lesson.
+
+Our seen-ID cache used to be written during the scrape. An aborted run then
+left notices flagged as handled that were never sent anywhere, and a retry
+skipped every one of them permanently. The first egress block did exactly that
+to **204 notices**.
+
+Persist the cache **after** the downstream write succeeds, and roll it back on
+failure, on dry runs, and on `--no-upload`.
+
+## Zero results is a failure
+
+There is deliberately no inference anywhere that a missing challenge means a
+cleared gate. That exact reasoning reported **13 consecutive dead runs as
+successful over 19 days**.
+
+Success requires positively seeing the content you came for.

--- a/docs/api/skip-trace.md
+++ b/docs/api/skip-trace.md
@@ -1,0 +1,178 @@
+# Skip trace: SmartSkip, Tracerfy, Enformion
+
+Three providers with different jobs. Using the wrong one for a job is the most
+common and most expensive mistake here.
+
+| Provider | Good at | Cost | Do not use for |
+|---|---|---|---|
+| SmartSkip | Relatives **with their phone numbers**, in one batch | $0.15 per hit | Death data. It is wrong about death |
+| Tracerfy | Cheap gap fill on a known person | $0.02 per record | Entities. Consumer only |
+| Enformion | LLC and trust principals | about $0.10 per match | The relatives graph. It whiffs half the time |
+
+## The measured comparison that set this order
+
+Twelve owners, same records, both providers, 2026-07-29:
+
+- **Coverage.** Enformion returned zero relatives on **6 of 12**. SmartSkip
+  returned relatives on 12 of 12.
+- **Phones.** Enformion's `relativesSummary` carries names but **no phone
+  numbers**, so every relative you actually want to call is another billed
+  search. SmartSkip returns relatives and their phones in the same row.
+- **Cost.** 100 owners, 682 relatives: **$15.90** the SmartSkip way,
+  **$78.20** the Enformion way. About 4.9x.
+- **Precision.** On the validation record SmartSkip returned exactly three
+  relatives and all three appeared in the published obituary. Enformion
+  returned a capped 50-name blob with out-of-state numbers that looked like
+  wrong-person bleed.
+
+That is why the heir engine is SmartSkip and Enformion is kept only for
+entities.
+
+---
+
+## SmartSkip
+
+Bulk skip trace. Fully drivable over the API.
+
+### The flow, and where the money is
+
+```
+upload      free
+map columns free
+calculate   free      <- returns the price, still costs nothing
+payment-intent        <- THIS is the only billing call
+poll + download
+```
+
+Everything up to `payment-intent` is free, so you can price a batch exactly
+before committing to it.
+
+### Three traps
+
+**The wallet does not pay for bulk skip.** It bills the saved card via
+`payment-intent`. We had $25 sitting untouched in the wallet while a batch
+charged the card. Funding the wallet does not prepay a batch.
+
+**Unpaid orders are invisible.** `GET /bulk-skip` does not list an order that
+has not been paid for. Persist the `bulkSkipId` the moment you get it, before
+paying, or you will lose track of a batch that exists but cannot be found.
+
+**Entities cannot be name-traced.** It needs a First and a Last. On one vacant
+owner list, **35 of 321** were LLCs or trusts. Filter them out before the batch
+and route them to Enformion, or you pay for guaranteed misses.
+
+### It is wrong about death
+
+`Deceased` came back `false` for a man who died 12/06/2025 with a published
+funeral home obituary. There is **no date-of-death column at all**.
+
+Death data comes from the obituary and web research pass. Always. Do not let a
+`Deceased` flag from here decide whether a record is an heir case.
+
+### Relationship labels are coarse
+
+The column is literally "Possible Type". On a 100-record batch, **63 percent**
+came back generic: "Relative" or "In-Law". It labelled a husband of 62 years a
+plain "Relative".
+
+Treat the label as a hint and let the obituary overwrite it. The obituary was
+written by someone who knew the family.
+
+---
+
+## Tracerfy
+
+Cheap batch gap fill. Use it for relatives SmartSkip named but left phoneless,
+which is roughly 7 percent.
+
+### Contract
+
+Multipart CSV upload with a Bearer token.
+
+**The `mail_*` columns are required or the request 400s.** Even when you have
+no mailing address, the columns have to be present. Send them empty rather than
+omitting them.
+
+### Phones come back flat, not as an array
+
+This surprises everyone once. There is no `phones` list. The fields are flat:
+
+```
+primary_phone
+mobile_1, mobile_2, ...
+landline_1, landline_2, ...
+```
+
+Parse the flat names. Code that looks for `phones[]` finds nothing and reports
+zero results on a batch that worked.
+
+### The deceased flag lives on the other endpoint
+
+The `deceased` boolean is on the **instant lookup** `persons[]` response, not
+on the $0.02 batch path. Batch gives you no death signal. There is no date of
+death on either.
+
+---
+
+## Enformion / Endato
+
+Kept for one job: resolving the humans behind an LLC or a trust.
+
+### Business search
+
+```
+POST devapi.enformion.com/BusinessV2Search
+  header galaxy-search-type: BusinessV2
+```
+
+**The v1 `BusinessSearch` type is access-denied** on this account tier, and
+`AddressSearch` is unlicensed. Both return failures that read like bugs rather
+than entitlement problems, which is a trap worth knowing before you spend an
+afternoon on it.
+
+Principals come from `usCorpFilings` and `newBusinessFilings`. Filter out
+entity self-references and commercial registered agent fronts, or you get
+"Northwest Registered Agent" as your decision maker.
+
+### Person search, if you use it at all
+
+**Anchor on the full street line for common names.** A name plus city and ZIP
+returned the wrong person as `persons[0]`: an Alabama "James B Key" for a
+Knoxville "James G Key". Only
+
+```json
+"Addresses": [{"AddressLine1": "7619 Trey Oaks Ln",
+               "AddressLine2": "Knoxville, TN 37918"}]
+```
+
+pinned the right record. `enformion_heir.person_search()` sends only
+`AddressLine2` by default, so pass the street line yourself on common names.
+
+**Detect failure by HTTP status, not by the `error` object.** That object is
+always present, including on success.
+
+### Its relatives graph is not trustworthy
+
+- `relativesSummary[].isDeceased` **lags and is wrong**. It showed a decedent,
+  his late wife and two long-deceased sons as living.
+- The graph is **capped at about 50** and truncates silently.
+- It **misses married-out daughters**, because they carry a different surname,
+  and they are frequently required signers.
+
+If you must use it, reconcile against the published obituary rather than
+trusting the graph.
+
+---
+
+## Cost per record, end to end
+
+The v5 chain: SmartSkip $0.15, Tracerfy gap fill about $0.02, obituary and web
+research free, Trestle scoring about $0.015 per number.
+
+**About $0.24 per record.** The retired Enformion-first path was about $1.18.
+
+## Without any of them
+
+[Heir research by hand](../setup/no-api-playbook.md#heir-research-by-hand). It
+takes 20 to 40 minutes a record and the obituary step is better than anything
+you can buy.

--- a/docs/api/smrtphone.md
+++ b/docs/api/smrtphone.md
@@ -1,0 +1,109 @@
+# smrtPhone
+
+Dialer and SMS. It has an API for some things, a web session for others, and
+the split is not where you would guess.
+
+- **Key:** `SMRTPHONE_API_KEY`, from Admin > API Tokens
+- **Used by:** the three coach skills, the SMS agent
+- **Verified:** 2026-08-10
+
+## What has an API and what does not
+
+| | API? |
+|---|---|
+| Send SMS (text) | yes |
+| Send MMS (image) | **no**, browser only |
+| Call logs and recordings | yes, via a DataTables endpoint |
+| Phone numbers list | **no**, returns the SPA shell to a key |
+| Webhooks in | yes |
+| DNT/DNC write | undocumented |
+
+## Sending text
+
+```
+POST phone.smrt.studio/sms/send
+  header X-Auth-smrtPhone: <key>
+  from, to, message
+```
+
+### The clean credential check
+
+`POST /sms/send` with **no parameters**:
+
+- valid key: `400 Missing required parameter(s): from, to, message`
+- bogus key: `403`
+
+That distinguishes a good key from a bad one and cannot send anything. Use it
+as your health check.
+
+**Do not probe `GET /dialerConfigs`.** It 405s on GET and serves the web app
+HTML on POST regardless of key, so it proves nothing either way. That is an
+hour you can skip.
+
+### MMS has no API
+
+Images go through the web app's compose UI, driven by Playwright. If you only
+ever send text, you never need the browser path.
+
+## Call logs and recordings
+
+```
+POST /logs/calls/filtered      (DataTables form post, cookie session)
+```
+
+Returns duration, disposition, caller, the CRM record link, and a **direct
+recording URL on `rec.smrtphone.io`**. That URL is public once known and needs
+no auth, which is what makes the coaching pipeline cheap.
+
+Filter to calls over about 60 seconds with a recording. Voicemails and
+wrong numbers are not calls, and grading them drags every average down.
+
+**Logs purge after 30 days.** If you want a coaching history, pull and store.
+
+## Finding the endpoints yourself
+
+`/phoneNumbers` and `/callerIds` return the SPA shell to an API key. The route
+that works is `POST /phoneNumbers/filtered`, another DataTables endpoint, and
+its fields come back as HTML fragments that need parsing.
+
+The trick that found it, and that works on the whole app:
+
+```
+GET /js/routing?callback=fos.Router.setData
+```
+
+That dumps roughly 1,187 named routes. It is a FOSJsRouting bundle and it is
+the fastest way to discover what this app can actually do.
+
+## Webhooks in
+
+`smsIncoming`, `smsOutgoing`, `smsDeliveryCallback`, `addNumberToDNT`,
+`addNumberToDNC`.
+
+`smsIncoming` carries `smsId, from, to, message, date, callerIdName, userName,
+contactName, source`.
+
+**They are unsigned.** Use a secret URL path and an IP allowlist, and keep your
+own event log, because their logs purge at 30 days.
+
+### The finding that changes how you route replies
+
+On a real send, **5 of 9 replies came from a different number than the one we
+texted.** People answer from whichever phone is in their hand.
+
+If you map only the number you sent to, most replies are unroutable. Map every
+phone on a record before the send, not just the target.
+
+## Sticky senders
+
+A conversation must keep the same sending number. Switching mid-thread reads as
+a spam farm to carriers and to the person.
+
+Caller ID persists and does not auto-rotate, so rotation is your job. Keep
+per-number daily volume low and never let one number carry a campaign.
+
+## Without a smrtPhone account
+
+The coach skills only need recordings and a rubric. Any dialer's export works.
+See [coaching without a dialer
+API](../setup/no-api-playbook.md#coaching-without-a-dialer-api).

--- a/docs/api/trestle.md
+++ b/docs/api/trestle.md
@@ -1,0 +1,69 @@
+# Trestle, phone intelligence
+
+Scores a phone number so you know what to dial first, and flags the numbers you
+should not dial at all.
+
+- **Key:** `TRESTLE_API_KEY`
+- **Cost:** about $0.015 per number
+- **Used by:** `phone-validator`, and the scoring pass at the end of every skip
+  trace chain
+
+## What you get back
+
+The endpoint is `phone_intel`. The parts that drive decisions:
+
+| Field | Why it matters |
+|---|---|
+| Activity score | The core ranking signal. Drives the tier |
+| Line type | Mobile beats landline for both SMS and pickup |
+| Connected status | Disconnected numbers leave the list permanently |
+| Contact grade | Confidence that this number belongs to this person |
+| Litigator flag | The one you cannot reproduce for free |
+
+## The five dial tiers
+
+These are fixed across every skill in the library. Keep them even if you score
+by other means, because the rest of the system reads them.
+
+| Score | Tier |
+|---|---|
+| 81 to 100 | Dial first |
+| 61 to 80 | Dial second |
+| 41 to 60 | Dial third |
+| 21 to 40 | Dial fourth |
+| 0 to 20 | Drop |
+
+Measured effect of dialing in tier order rather than list order: about **4.75x**
+the connect rate. That number is the entire argument for the $0.015.
+
+## Rules that matter more than the score
+
+**Score every number, then dedupe.** Skip trace sources overlap heavily and the
+same number arrives from several. Scoring after the union means you pay once
+per unique number instead of once per source hit.
+
+**Cross-confirmation beats score.** A number that appeared in two independent
+sources outranks a single-source number at the same score. Carry a
+`confirm_count` alongside the score; it is free and it is a better signal than
+the last ten points of score.
+
+**On a shared household line, the owner rule wins.** If a number belongs to
+both the owner and a relative, label it with source and tier only, never with
+the relationship. Otherwise the dial sheet tells a caller that the owner's own
+landline is "Husband", and the call opens wrong.
+
+**The litigator flag is the reason to pay.** Activity and line type you can
+approximate for free. TCPA and litigator risk you cannot. If you dial at
+volume, this check pays for itself the first time it fires.
+
+## Two keys
+
+`TRESTLE_FREE_API_KEY` and `TRESTLE_PAID_API_KEY` exist in the example env.
+The free tier is for validating your integration. Do not run production
+scoring through it and conclude the data is thin.
+
+## Without the key
+
+[Phone scoring without Trestle](../setup/no-api-playbook.md#phone-scoring-without-trestle).
+You can recover most of the ordering value from line type, recency and
+cross-source confirmation. You cannot recover litigator screening.

--- a/docs/setup/GETTING-STARTED.md
+++ b/docs/setup/GETTING-STARTED.md
@@ -1,0 +1,163 @@
+# Getting started
+
+Install the library, find out what you can already run, then add credentials
+only for the things you actually want.
+
+Nine skills work the moment they are installed. You do not need an API key,
+a developer account, or a credit card to get value out of this on day one.
+
+## 1. Install
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/install.py | python3 -
+
+# Windows PowerShell
+irm https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/install.py | python -
+```
+
+Python 3.9 or newer, standard library only. No clone, no `pip install`, no
+virtualenv. Skills land in `~/.claude/skills/`, plugins in `~/.claude/plugins/`.
+
+Restart Claude Code afterwards. You do not invoke skills by name: describe the
+task and the right one triggers.
+
+On Claude Co-Work or claude.ai, download the package you want from
+[`dist/`](../../dist/) and upload it to your session or Project instead.
+
+## 2. Find out where you stand
+
+```bash
+python3 install.py --doctor
+```
+
+It reads your environment and a `.env` if you have one, then prints three
+groups: what works right now, what needs you signed in somewhere, and what
+needs a credential. Every blocked skill prints its no-API alternative on the
+same line, so you never get told no without being told what to do instead.
+
+It sends no requests and spends nothing. It never prints a credential value,
+only whether a name is set.
+
+## 3. Choose your path
+
+There are three tiers, and most people should stop after tier 1 for a while.
+
+### Tier 1: no credentials
+
+Works on install. Nine packages.
+
+| Skill | What you get |
+|---|---|
+| `rehab-estimator` | Room-by-room rehab costs across 4 tiers, with a real material list |
+| `real-estate-comping` | Full comping method by browser. Zillow, Redfin, Realtor, by hand |
+| `first-market-county-data` | Where to pull county distress lists for any US county |
+| `probate-property-finder` | Find the property behind a probate filing, using free portals |
+| `buyer-prospector` | Cash buyer list for any county, ships its own data |
+| `team-hiring` | Who to hire, what to pay, where to post, how to interview |
+| `playbook-creator` | Turn a recording or transcript into a real SOP |
+| `text-touch-builder` | Four-touch pre-call SMS sequence per record |
+| `sift-operations` | The CRM operations encyclopedia |
+
+### Tier 2: a login you already have
+
+No API keys. These drive a browser, or mint their own token from your own
+account credentials.
+
+| Skill | Needs | Set |
+|---|---|---|
+| `sift-market-research` | DataSift login | `DATASIFT_EMAIL`, `DATASIFT_PASSWORD` |
+| `sequential-presets` | DataSift login | `DATASIFT_EMAIL`, `DATASIFT_PASSWORD` |
+| `sift-sequences` | DataSift login | `DATASIFT_EMAIL`, `DATASIFT_PASSWORD` |
+| `kpi-engine` | DataSift login | `REISIFT_TOKEN`, or it mints one from your login |
+| `cold-call-coach` | SmrtPhone session, a transcription model | Browser session, `OPENROUTER_API_KEY` |
+| `lead-manager-coach` | same | same |
+| `closer-coach` | same | same |
+| `candidate-intake` | Google account, Claude in Chrome | Nothing to set, it runs in the browser |
+
+The three DataSift skills use Playwright to drive the web app the same way you
+would by hand. That is deliberate: it means you need no API access at all, and
+it works on any DataSift plan.
+
+### Tier 3: a metered API key
+
+Faster and more thorough, and every one of them has a no-API alternative.
+
+| Skill | Key | Cost | Without it |
+|---|---|---|---|
+| `comp-package` | `OPENWEBNINJA_API_KEY` | 100 free/month | Use `real-estate-comping` |
+| `deal-analyzer` | `OPENWEBNINJA_API_KEY` | 100 free/month | Use `real-estate-comping` |
+| `phone-validator` | `TRESTLE_API_KEY` | $0.015 per number | [Phone scoring by hand](no-api-playbook.md#phone-scoring-without-trestle) |
+| `deep-prospecting-v5` | SmartSkip, Trestle | about $0.24 per record | [Heir research by hand](no-api-playbook.md#heir-research-by-hand) |
+| `caller-reputation-monitor` | `TELNYX_API_KEY` | included with Telnyx | [Spam checks by hand](no-api-playbook.md#spam-flag-checks-by-hand) |
+
+## 4. Add credentials
+
+Copy the example and fill in only what you want. Everything is optional.
+
+```bash
+curl -fsSL -o .env.skills.example https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/.env.skills.example
+cp .env.skills.example .env
+```
+
+Skills read from your environment. Either export the variables in your shell
+profile, or keep a `.env` in the folder you work from.
+
+**Every skill degrades rather than failing.** A missing key means that step is
+skipped and the run says so. Nothing hard-fails because you did not sign up
+for something.
+
+Re-run `python3 install.py --doctor` and the skill moves out of the blocked
+list.
+
+## 5. Use them
+
+Describe the task. Do not name the skill.
+
+- "Run comps on 123 Main St, Knoxville TN 37914" triggers the comping stack.
+- "Estimate the rehab on this, three bed one bath, 1,100 square feet, full gut"
+  triggers `rehab-estimator`.
+- "Who should I hire next and what do I pay them" triggers `team-hiring`.
+- "Grade yesterday's cold calls" triggers `cold-call-coach`.
+
+If nothing triggers, the skill either is not installed or its description does
+not match how you phrased it. `python3 install.py --list` shows every
+description, and those are what Claude matches against.
+
+## Keeping up to date
+
+```bash
+python3 install.py            # re-run any time, skips what is current
+python3 install.py --force    # reinstall everything
+```
+
+Each installed package carries a `.siftstack-version` file holding the SHA-256
+of the archive it came from. That is how the installer knows what is current,
+and it is why re-running is cheap and safe.
+
+## Where things are
+
+| | |
+|---|---|
+| No-API routes for every paid step | [`no-api-playbook.md`](no-api-playbook.md) |
+| API contracts and their gotchas | [`../api/`](../api/) |
+| The agent system these skills drive | [`../AGENT-MAP.md`](../AGENT-MAP.md) |
+| Interactive map | [learn.datasift.ai/agent-org-chart](https://learn.datasift.ai/agent-org-chart) |
+
+## When something does not work
+
+Run the doctor first. It answers most of it.
+
+**A skill never triggers.** Check it is installed and read its description with
+`--list`. Describe your task in those words.
+
+**TLS or certificate errors during install.** Usually a corporate proxy
+intercepting HTTPS. Clone the repo and run `install.py` from inside it.
+
+**GitHub rate limits partway through.** Installing everything is 24 requests.
+The installer backs off and retries, and if it still gives up, wait a few
+minutes and re-run: finished packages are skipped and it resumes.
+
+**A paid step returns nothing.** Check the balance on that account before
+assuming the skill is broken. Most of these APIs return an empty result rather
+than an error when you are out of credit.

--- a/docs/setup/no-api-playbook.md
+++ b/docs/setup/no-api-playbook.md
@@ -1,0 +1,248 @@
+# The no-API playbook
+
+Every paid step in this library has a route that needs no API key. They are
+slower and they need you in the loop, but they produce the same answer, and
+several of them are what the paid path was built from in the first place.
+
+Three techniques carry all of it:
+
+1. **Browser automation.** Playwright drives a site the way you would. This is
+   how the DataSift skills work already: no API access, just your own login.
+2. **Claude in Chrome.** The extension reads and acts on pages you are signed
+   in to. Best where a site actively blocks automation.
+3. **By hand, with Claude doing the reading.** You paste or screenshot, Claude
+   structures it. Slow per record, free, and often the most accurate.
+
+Pick by volume. Under about 20 records, do it by hand. Over a few hundred, the
+paid API is cheaper than your time.
+
+---
+
+## Comping without OpenWeb Ninja
+<a id="comping-without-an-api"></a>
+
+**Use the `real-estate-comping` skill.** It is not a degraded fallback, it is
+the full method with manual comp collection, and it ships with the same
+two-bucket ARV logic and adjustment tables as the paid path.
+
+What changes: you gather the sold comps yourself from Zillow, Redfin,
+Realtor.com and Homes.com instead of the API returning them.
+
+What does not change: the boundary discipline, the condition bucketing, the
+bedroom-band rule, and the dual-track ARV all still apply, and those are what
+actually decide the number.
+
+Practical notes:
+
+- Pull from at least two sites. They disagree, and the disagreement is
+  information.
+- In non-disclosure states the listing sites will not show sold prices. The
+  skill routes you to the county assessor instead, which is free everywhere.
+- Screenshot the comp table and hand it to Claude rather than retyping it.
+- The 41-row cap that forces price-band partitioning on the API does not exist
+  when you browse, so a wide search is genuinely easier by hand.
+
+**When to buy the key.** If you are comping more than about five properties a
+month. 100 lookups a month are free, and a single property is several lookups.
+
+---
+
+## Market research without a DataSift login
+<a id="market-research"></a>
+
+`sift-market-research` drives Market Finder in a browser, so it already needs
+no API. If you have no DataSift account at all:
+
+- Census QuickFacts and the ACS give you population, income, ownership rate and
+  vacancy for any county or ZIP, free.
+- FRED carries days-on-market, median sale price and inventory by metro.
+- Your county assessor's sales file gives real transaction volume, which is the
+  number that actually matters. `first-market-county-data` tells you where it
+  lives for your county.
+
+Score the ZIPs yourself with the same six weights the skill uses: distress 30,
+value 20, equity 15, tax delinquency 15, competition 10, days on market 10.
+The weights are the method. The data source is interchangeable.
+
+---
+
+## Presets by hand
+<a id="presets-by-hand"></a>
+
+`sequential-presets` clicks through the DataSift filter UI for you. Without the
+automation, ask Claude for the preset definition and build it yourself:
+
+> Give me the filter definition for the "00. Needs Skipped" niche sequential
+> preset: every filter block, the exact values, and the order.
+
+The skill's references carry all 21 preset definitions as data. Reading them
+out and building 21 presets by hand is about an hour, once, and then they exist
+forever. The automation is a convenience, not a dependency.
+
+Same for the Sold exclusion: it is one filter block added to each preset.
+
+---
+
+## Sequences by hand
+<a id="sequences-by-hand"></a>
+
+`sift-sequences` builds sequences through the UI with drag and drop, which is
+the fiddliest automation in the library and the most likely to need a retry.
+Doing it by hand is often faster.
+
+Ask for the definition, then build it:
+
+> Give me the full definition for the HOT A01 sequence: trigger, conditions,
+> every action in order, and the delay on each.
+
+All 26 templates are in the skill's references. The value is the template
+design, not the clicking.
+
+---
+
+## KPIs by hand
+<a id="kpis-by-hand"></a>
+
+`kpi-engine` mints a token from your own DataSift login, so it is not really an
+API-access question. If you would rather not automate at all:
+
+Export the activity log from DataSift for the period, then hand Claude the CSV:
+
+> Here is my activity export. Give me dials, contacts, correct numbers, leads
+> including new_lead statuses, and talk time, per caller and account-wide, then
+> grade it against these targets: 2 to 3 leads per day, 15 to 20 leads per
+> contract.
+
+The one thing to watch is the lead count. Most manual reports miss the
+`new_lead` statuses and undercount leads, which makes every downstream rate
+wrong. Say the words "including new_lead statuses" and you avoid it.
+
+---
+
+## Phone scoring without Trestle
+<a id="phone-scoring-without-trestle"></a>
+
+Trestle scores a number for line type, activity and litigator risk at about
+$0.015. Without it, you can recover most of the dial-order value free:
+
+- **Line type** from a free carrier lookup. Mobile beats landline for SMS and
+  for pickup.
+- **Disconnected numbers** surface on the first dial. One pass through a list
+  removes them permanently, so the cost is one wasted call each.
+- **Order by source instead.** A number that appeared in two independent skip
+  trace sources outranks a single-source number, and that is free to compute:
+  it is just counting.
+- **Recency beats everything.** The most recently reported number for a person
+  outperforms an older one regardless of score.
+
+Keep the same five tiers so the rest of the system still works: 81 to 100 dial
+first, 61 to 80 second, 41 to 60 third, 21 to 40 fourth, 20 and under drop.
+Assign them from what you know rather than from a score.
+
+**The one thing you cannot replicate.** Litigator and TCPA risk flagging. If
+you are dialing at volume, that check is worth the money on its own, and it is
+the reason to buy the key even if you skip everything else.
+
+---
+
+## Heir research by hand
+<a id="heir-research-by-hand"></a>
+
+`deep-prospecting-v5` costs about $0.24 a record and it is the best value in
+the library. But the free version is genuinely good, and it is where the paid
+method came from.
+
+The chain, per decedent:
+
+1. **Confirm the death.** Obituary sites, funeral home notices, FindAGrave.
+   Free and authoritative.
+2. **Check the decedent against the owner of record** before anything else.
+   This is the single most important step and it is free. An obituary on a
+   record does not mean the owner died: it is frequently the spouse. Getting
+   this wrong means asking a recent widow for her dead husband.
+3. **Pull relatives from the obituary itself.** Survivor lists name the
+   children, the spouse and often the grandchildren, in order, with married
+   surnames. This is better data than most paid relative graphs, because a
+   human who knew the family wrote it.
+4. **Find the probate filing.** County clerk or court portal, usually free and
+   searchable by name. It names the personal representative, who is the person
+   with authority to sign.
+5. **Get phone numbers** from free people-search sites: TruePeopleSearch,
+   CyberBackgroundChecks, FastPeopleSearch. Expect to work around bot walls.
+6. **Rank the signers** by TN-style intestacy order, or your state's, which the
+   skill's references carry.
+
+This takes about 20 to 40 minutes a record versus a few minutes paid. At low
+volume that is fine. At any real volume, buy the key.
+
+**Do not skip step 2 just because you are in a hurry.** It is the check the
+paid path cannot do for you either.
+
+---
+
+## Spam flag checks by hand
+<a id="spam-flag-checks-by-hand"></a>
+
+`caller-reputation-monitor` polls Telnyx for the reputation of every outbound
+number. Without it:
+
+- **Call your own numbers** from a phone on each major carrier and look at what
+  the screen says. Tedious, completely accurate, and free. Once a week per
+  number is enough to catch a flag early.
+- **Register with the free carrier lookup portals.** The major US carriers each
+  run one, and they will show you a number's current label and accept a
+  remediation request.
+- **Watch your own answer rate per number.** A number that was answering at 8
+  percent and drops to 2 has almost certainly been flagged, and you will see
+  that in your dialer stats before any portal tells you.
+
+The mitigations are the same either way and they matter more than the
+monitoring: rotate numbers, keep per-number daily volume low, never let one
+number carry a whole campaign, and retire a flagged number rather than trying
+to rehabilitate it while still dialing from it.
+
+---
+
+## Coaching without a dialer API
+<a id="coaching-without-a-dialer-api"></a>
+
+The three coach skills pull recordings from SmrtPhone. If you use a different
+dialer, or none:
+
+1. **Export the recordings.** Every dialer has a download, even if it is one at
+   a time. You only need a handful: five real conversations tells you more than
+   fifty voicemails.
+2. **Transcribe.** Any audio model works. If you would rather not use one at
+   all, most dialers ship a built-in transcript, and free transcription tools
+   are adequate for grading.
+3. **Grade against the rubric.** This is the part that matters and it needs no
+   integration:
+
+> Grade this call against the cold-calling rubric: opener, motivation probing
+> across the four pillars, objection handling, tonality, and close quality.
+> Score each, quote the exact moment it went wrong, and give me one thing to
+> change on the next call.
+
+The rubric lives in the skill's references and is the actual product. The
+pulling and transcribing are plumbing.
+
+**One thing to keep.** Grade only real conversations. Voicemails and wrong
+numbers are not calls, and scoring them drags every average down and hides the
+signal in the calls that were real.
+
+---
+
+## What has no substitute
+
+Being honest about the limits:
+
+- **Litigator and TCPA risk screening.** If you dial at volume, buy it.
+- **Bulk skip trace at scale.** Free people-search sites bot-block hard and do
+  not do batches. Under about 50 records a month you can work by hand. Above
+  that you cannot.
+- **Deed-level buyer data.** Some of this exists only behind a paid parcel API
+  or a title account. County records have it, but assembled by hand it is
+  days of work per county rather than minutes.
+
+Everything else in this library has a free route that gets you to the same
+decision.

--- a/install.py
+++ b/install.py
@@ -221,6 +221,110 @@ def install_one(entry: dict, dest_root: Path, local: bool, dry: bool, force: boo
     return "updated" if existed else "installed"
 
 
+def _load_dotenv() -> dict:
+    """Read a .env in the current directory, if there is one.
+
+    Not a dotenv library, and deliberately not exported into os.environ: the
+    doctor only needs to know which names are SET, never their values, so it
+    never has to hold a credential in memory or risk printing one.
+    """
+    found = {}
+    for path in (Path.cwd() / ".env", HERE / ".env"):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            if v.strip().strip("'\""):
+                found[k.strip()] = True
+    return found
+
+
+def doctor(doc: dict) -> int:
+    """Report what runs right now, what needs a credential, what to do instead.
+
+    The point is that nobody discovers a missing key by watching a skill fail
+    halfway through a real deal. Every blocked skill prints its fallback on
+    the same line, so "I cannot run this" always comes with "do this instead".
+    """
+    dotenv = _load_dotenv()
+    have = lambda k: bool(os.environ.get(k)) or k in dotenv  # noqa: E731
+
+    entries = [e for e in doc["skills"] if e["status"] == "current"]
+    ready, login, blocked = [], [], []
+    for e in entries:
+        req = e["requires"]
+        missing = [k for k in req.get("env", []) if not have(k)]
+        if missing:
+            blocked.append((e, missing))
+        elif req.get("accounts"):
+            # Env vars are satisfied but the skill still drives a service you
+            # have to be signed in to. Calling that "ready" would be a lie the
+            # person only discovers when the browser lands on a login page.
+            login.append((e, []))
+        else:
+            ready.append((e, []))
+
+    say(f"\n{BOLD}SiftStack skill library, readiness check{OFF}")
+    say(f"{DIM}{len(entries)} current packages. Nothing here sends a request or spends money.{OFF}\n")
+
+    if dotenv:
+        say(f"{DIM}Read a .env with {len(dotenv)} value(s) set. Values are never displayed.{OFF}\n")
+
+    say(f"{GREEN}Works right now, nothing to configure{OFF}  {DIM}({len(ready)} of {len(entries)}){OFF}")
+    for e, _ in ready:
+        say(f"  {GREEN}+{OFF} {e['name']}")
+
+    if login:
+        say(f"\n{BOLD}Keys are set, but you need to be signed in{OFF}  {DIM}({len(login)}){OFF}")
+        for e, _ in login:
+            accts = ", ".join(e["requires"]["accounts"])
+            say(f"  {GREEN}+{OFF} {e['name']:<28} {DIM}sign in to {accts}{OFF}")
+
+    if blocked:
+        say(f"\n{YELLOW}Needs a credential{OFF}  {DIM}({len(blocked)}){OFF}")
+        for e, missing in blocked:
+            say(f"  {YELLOW}-{OFF} {e['name']:<28} {DIM}set {', '.join(missing)}{OFF}")
+            cost = e["requires"].get("cost")
+            if cost and cost != "Free":
+                say(f"      {DIM}cost: {cost}{OFF}")
+            fb = e["requires"].get("fallback")
+            if fb:
+                if "#" in fb:
+                    say(f"      {DIM}without it: docs/setup/{fb.replace('#', '.md, section ')}{OFF}")
+                else:
+                    known = [x["name"] for x, _ in ready] + [x["name"] for x, _ in login]
+                    ok = "already installed" if fb in known else "install it"
+                    say(f"      {DIM}without it: use the {fb} skill ({ok}){OFF}")
+            else:
+                say(f"      {DIM}without it: no substitute, this one needs the key{OFF}")
+
+    # Accounts are logins rather than env vars, so they cannot be detected.
+    # Listing them is the only honest thing to do.
+    accounts = {}
+    for e in entries:
+        for a in e["requires"].get("accounts", []):
+            accounts.setdefault(a, []).append(e["name"])
+    if accounts:
+        say(f"\n{BOLD}Logins these assume you already have{OFF}")
+        say(f"{DIM}Cannot be checked from here. Confirm you can sign in.{OFF}")
+        for a in sorted(accounts):
+            names = accounts[a]
+            shown = ", ".join(names[:3]) + (f" +{len(names) - 3} more" if len(names) > 3 else "")
+            say(f"  {a:<26} {DIM}{shown}{OFF}")
+
+    say(f"\n{BOLD}Next{OFF}")
+    if blocked:
+        say("  Copy .env.skills.example to .env and fill in only the keys you want.")
+        say("  Every skill degrades rather than failing: a missing key skips that step.")
+    say("  Full setup guide:   docs/setup/GETTING-STARTED.md")
+    say("  No-API routes:      docs/setup/no-api-playbook.md")
+    say("  API contracts:      docs/api/\n")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -233,10 +337,15 @@ def main() -> int:
     ap.add_argument("--dry-run", action="store_true", help="report what would change, write nothing")
     ap.add_argument("--force", action="store_true", help="reinstall even if already current")
     ap.add_argument("--remote", action="store_true", help="ignore a local checkout, always fetch")
+    ap.add_argument("--doctor", action="store_true",
+                    help="what works right now, what needs a key, and what to do instead")
     args = ap.parse_args()
 
     doc, local = load_manifest(prefer_local=not args.remote)
     entries = doc["skills"]
+
+    if args.doctor:
+        return doctor(doc)
 
     if args.list:
         say(f"\n{BOLD}SiftStack REI skill library{OFF}  "

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -17,6 +17,16 @@
     "Market Intelligence",
     "Operations"
   ],
+  "tiers": {
+    "none": "Works the moment it is installed. No key, no login.",
+    "account": "Needs a login for a service you already pay for.",
+    "api": "Needs a third-party API key, usually metered."
+  },
+  "tier_counts": {
+    "none": 10,
+    "account": 7,
+    "api": 5
+  },
   "skills": [
     {
       "name": "sift-operations",
@@ -47,7 +57,14 @@
       "file_count": 16,
       "bytes": 98997,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/sift-operations.plugin",
-      "sha256": "0bc86547e8c4db6e321d5f92cc060ae91774973a8e0b30646f9bbcf59ca03349"
+      "sha256": "0bc86547e8c4db6e321d5f92cc060ae91774973a8e0b30646f9bbcf59ca03349",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "sift-sequences",
@@ -71,7 +88,19 @@
       "file_count": 9,
       "bytes": 107992,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/sift-sequences.skill",
-      "sha256": "fa5df619c5a911a4ade196e8fbe5dcbb769d9cf9021210920861dddcbe497a2c"
+      "sha256": "fa5df619c5a911a4ade196e8fbe5dcbb769d9cf9021210920861dddcbe497a2c",
+      "requires": {
+        "tier": "account",
+        "env": [
+          "DATASIFT_EMAIL",
+          "DATASIFT_PASSWORD"
+        ],
+        "accounts": [
+          "DataSift"
+        ],
+        "cost": "Included with DataSift",
+        "fallback": "no-api-playbook#sequences-by-hand"
+      }
     },
     {
       "name": "closer-coach",
@@ -94,7 +123,17 @@
       "file_count": 8,
       "bytes": 76898,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/closer-coach.skill",
-      "sha256": "d795bfa383c10e3cac099cc31bd736046cdd522dda9face1580ecd3742d910b1"
+      "sha256": "d795bfa383c10e3cac099cc31bd736046cdd522dda9face1580ecd3742d910b1",
+      "requires": {
+        "tier": "account",
+        "accounts": [
+          "SmrtPhone",
+          "OpenRouter or Anthropic"
+        ],
+        "cost": "About $0.002 per audio minute to transcribe",
+        "fallback": "no-api-playbook#coaching-without-a-dialer-api",
+        "env": []
+      }
     },
     {
       "name": "cold-call-coach",
@@ -122,7 +161,17 @@
       "file_count": 13,
       "bytes": 104768,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/cold-call-coach.skill",
-      "sha256": "a50055ea32e7eb853e0f29c1f869346edf557b6d1b5c253840b3a319587267c7"
+      "sha256": "a50055ea32e7eb853e0f29c1f869346edf557b6d1b5c253840b3a319587267c7",
+      "requires": {
+        "tier": "account",
+        "accounts": [
+          "SmrtPhone",
+          "OpenRouter or Anthropic"
+        ],
+        "cost": "About $0.002 per audio minute to transcribe",
+        "fallback": "no-api-playbook#coaching-without-a-dialer-api",
+        "env": []
+      }
     },
     {
       "name": "kpi-engine",
@@ -140,7 +189,19 @@
       "file_count": 3,
       "bytes": 33180,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/kpi-engine.skill",
-      "sha256": "a33f6806787f25298b95359325b82485467b8eadcdc686fdf357c5448712c8cc"
+      "sha256": "a33f6806787f25298b95359325b82485467b8eadcdc686fdf357c5448712c8cc",
+      "requires": {
+        "tier": "account",
+        "env": [
+          "REISIFT_TOKEN"
+        ],
+        "accounts": [
+          "DataSift"
+        ],
+        "cost": "Included with DataSift",
+        "fallback": "no-api-playbook#kpis-by-hand",
+        "note": "Mints its own token from your DataSift login. No internal API access needed."
+      }
     },
     {
       "name": "lead-manager-coach",
@@ -163,7 +224,17 @@
       "file_count": 8,
       "bytes": 76590,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/lead-manager-coach.skill",
-      "sha256": "6eb37dd410c56d7f9101469c446cbb1e9aedcdf2e468bac9caed7c3ea68fc4bc"
+      "sha256": "6eb37dd410c56d7f9101469c446cbb1e9aedcdf2e468bac9caed7c3ea68fc4bc",
+      "requires": {
+        "tier": "account",
+        "accounts": [
+          "SmrtPhone",
+          "OpenRouter or Anthropic"
+        ],
+        "cost": "About $0.002 per audio minute to transcribe",
+        "fallback": "no-api-playbook#coaching-without-a-dialer-api",
+        "env": []
+      }
     },
     {
       "name": "comp-package",
@@ -183,7 +254,17 @@
       "file_count": 5,
       "bytes": 17801,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/comp-package.skill",
-      "sha256": "61c5ccfbae1434497ac248908bbea4cd724be6e638828ca809b6a86f1cf38f5e"
+      "sha256": "61c5ccfbae1434497ac248908bbea4cd724be6e638828ca809b6a86f1cf38f5e",
+      "requires": {
+        "tier": "api",
+        "env": [
+          "OPENWEBNINJA_API_KEY"
+        ],
+        "cost": "100 free lookups per month, then metered",
+        "fallback": "real-estate-comping",
+        "note": "Without the key, real-estate-comping does the same job by browser.",
+        "accounts": []
+      }
     },
     {
       "name": "deal-analyzer",
@@ -216,7 +297,17 @@
       "file_count": 18,
       "bytes": 312860,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/deal-analyzer.plugin",
-      "sha256": "f7802ed3f4bc46b5ff29198f7d4e863391324f44f939048c91c6a0f090aa4414"
+      "sha256": "f7802ed3f4bc46b5ff29198f7d4e863391324f44f939048c91c6a0f090aa4414",
+      "requires": {
+        "tier": "api",
+        "env": [
+          "OPENWEBNINJA_API_KEY"
+        ],
+        "cost": "100 free lookups per month, then metered",
+        "fallback": "real-estate-comping",
+        "note": "Comping stage only. Rehab and offer math need no key.",
+        "accounts": []
+      }
     },
     {
       "name": "deep-prospecting",
@@ -233,7 +324,15 @@
       "bytes": 40432,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/deep-prospecting.skill",
       "sha256": "3fb7b821ad483bd5288dac89404e6c89c37da8ee5730172a2c0bf8e5393aa743",
-      "superseded_by": "deep-prospecting-v5"
+      "superseded_by": "deep-prospecting-v5",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "note": "Superseded. Manual research method.",
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "deep-prospecting-v4",
@@ -256,7 +355,19 @@
       "bytes": 85288,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/deep-prospecting-v4.skill",
       "sha256": "02ee79406e8f8cfffc7df2a0561a382956613a504849553108803538162d18af",
-      "superseded_by": "deep-prospecting-v5"
+      "superseded_by": "deep-prospecting-v5",
+      "requires": {
+        "tier": "api",
+        "env": [
+          "ENFORMION_AP_NAME",
+          "ENFORMION_AP_PASSWORD",
+          "TRESTLE_API_KEY"
+        ],
+        "cost": "About $1.18 per record",
+        "fallback": "deep-prospecting-v5",
+        "note": "Superseded. v5 is roughly 5x cheaper and finds more.",
+        "accounts": []
+      }
     },
     {
       "name": "deep-prospecting-v5",
@@ -283,7 +394,19 @@
       "file_count": 12,
       "bytes": 79198,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/deep-prospecting-v5.skill",
-      "sha256": "5a1527b3a13b5d9bc878ff5dba84dc5cf1a29399439fdb1b94df0b7f889b6554"
+      "sha256": "5a1527b3a13b5d9bc878ff5dba84dc5cf1a29399439fdb1b94df0b7f889b6554",
+      "requires": {
+        "tier": "api",
+        "env": [
+          "SMARTSKIP_EMAIL",
+          "SMARTSKIP_PASSWORD",
+          "TRESTLE_API_KEY"
+        ],
+        "cost": "About $0.24 per record end to end",
+        "fallback": "no-api-playbook#heir-research-by-hand",
+        "note": "Enformion is optional and only needed for LLC and trust owners.",
+        "accounts": []
+      }
     },
     {
       "name": "probate-property-finder",
@@ -299,7 +422,15 @@
       "file_count": 1,
       "bytes": 32693,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/probate-property-finder.skill",
-      "sha256": "c6fd3275ad21c8b8dfb347ed3cd8021f1b5ca4130a0e19034d34953f38aff22f"
+      "sha256": "c6fd3275ad21c8b8dfb347ed3cd8021f1b5ca4130a0e19034d34953f38aff22f",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "note": "Uses free county tax portals and people-search sites.",
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "real-estate-comping",
@@ -320,7 +451,15 @@
       "file_count": 6,
       "bytes": 83133,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/real-estate-comping.skill",
-      "sha256": "33e7abcf50d360f19efd1b3fe71baf328f7dab346883a18087f90f35de3eefd9"
+      "sha256": "33e7abcf50d360f19efd1b3fe71baf328f7dab346883a18087f90f35de3eefd9",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "note": "This IS the no-key comping route: manual Zillow, Redfin and Realtor pulls.",
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "rehab-estimator",
@@ -343,7 +482,15 @@
       "file_count": 8,
       "bytes": 222946,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/rehab-estimator.skill",
-      "sha256": "e4108473498a3300cab4e7f5caec4513f72b9e93b2500c224fb7e2696346fef8"
+      "sha256": "e4108473498a3300cab4e7f5caec4513f72b9e93b2500c224fb7e2696346fef8",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "note": "Ships the locked Knox material list. Other markets use the cheat sheet.",
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "buyer-prospector",
@@ -362,7 +509,15 @@
       "file_count": 4,
       "bytes": 6735501,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/buyer-prospector.skill",
-      "sha256": "183e67e0cfbe0ee2c9b7711041d4d49b927a8d58afe8edaaf05a9790c674c516"
+      "sha256": "183e67e0cfbe0ee2c9b7711041d4d49b927a8d58afe8edaaf05a9790c674c516",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "note": "Ships its own nationwide buyer data. Entity research is browser-driven.",
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "first-market-county-data",
@@ -383,7 +538,15 @@
       "file_count": 6,
       "bytes": 142423,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/first-market-county-data.skill",
-      "sha256": "cd2fb68216cf76da4ec0b3c3158bd9c2f64a38d7556a6d43445470e4901ba8f6"
+      "sha256": "cd2fb68216cf76da4ec0b3c3158bd9c2f64a38d7556a6d43445470e4901ba8f6",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "note": "Tells you where to pull county data. The pulling is manual by design.",
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "sift-market-research",
@@ -405,7 +568,20 @@
       "file_count": 7,
       "bytes": 12095045,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/sift-market-research.skill",
-      "sha256": "fa33ec18ebc641fecd3dbafe2c0823ca063e989de3168f6836c5ad89cff6722a"
+      "sha256": "fa33ec18ebc641fecd3dbafe2c0823ca063e989de3168f6836c5ad89cff6722a",
+      "requires": {
+        "tier": "account",
+        "env": [
+          "DATASIFT_EMAIL",
+          "DATASIFT_PASSWORD"
+        ],
+        "accounts": [
+          "DataSift"
+        ],
+        "cost": "Included with DataSift",
+        "fallback": "no-api-playbook#market-research",
+        "note": "Browser automation of Market Finder. Your login, not an API key."
+      }
     },
     {
       "name": "caller-reputation-monitor",
@@ -438,7 +614,19 @@
       "file_count": 18,
       "bytes": 215945,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/caller-reputation-monitor.skill",
-      "sha256": "6dfa469f64d4f911f680a9d45003050806b9e68f76ee3163d6ed094d72d53e5c"
+      "sha256": "6dfa469f64d4f911f680a9d45003050806b9e68f76ee3163d6ed094d72d53e5c",
+      "requires": {
+        "tier": "api",
+        "env": [
+          "TELNYX_API_KEY",
+          "TELNYX_ENTERPRISE_ID"
+        ],
+        "accounts": [
+          "Telnyx"
+        ],
+        "cost": "Included with a Telnyx account",
+        "fallback": "no-api-playbook#spam-flag-checks-by-hand"
+      }
     },
     {
       "name": "candidate-intake",
@@ -465,7 +653,18 @@
       "file_count": 12,
       "bytes": 43658,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/candidate-intake.skill",
-      "sha256": "17c513c2468cdd2125373950c1708783feeebeb483749ea35ad3a79dca5dff9f"
+      "sha256": "17c513c2468cdd2125373950c1708783feeebeb483749ea35ad3a79dca5dff9f",
+      "requires": {
+        "tier": "none",
+        "accounts": [
+          "Google",
+          "Claude in Chrome"
+        ],
+        "fallback": null,
+        "note": "Runs entirely through the Chrome extension. No API keys.",
+        "env": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "phone-validator",
@@ -486,7 +685,16 @@
       "file_count": 6,
       "bytes": 76925,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/phone-validator.skill",
-      "sha256": "bc00ed89023f1c572b9beb2f390fa7cd465924d26e901f3f0be5c98ee293d850"
+      "sha256": "bc00ed89023f1c572b9beb2f390fa7cd465924d26e901f3f0be5c98ee293d850",
+      "requires": {
+        "tier": "api",
+        "env": [
+          "TRESTLE_API_KEY"
+        ],
+        "cost": "About $0.015 per number",
+        "fallback": "no-api-playbook#phone-scoring-without-trestle",
+        "accounts": []
+      }
     },
     {
       "name": "playbook-creator",
@@ -511,7 +719,14 @@
       "file_count": 10,
       "bytes": 113610,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/playbook-creator.skill",
-      "sha256": "9c24cd232114f77c115181b74f53a2a515f49c579b682b90d72f7fe297f95bc7"
+      "sha256": "9c24cd232114f77c115181b74f53a2a515f49c579b682b90d72f7fe297f95bc7",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "sequential-presets",
@@ -532,7 +747,19 @@
       "file_count": 6,
       "bytes": 65292,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/sequential-presets.skill",
-      "sha256": "7907c114b3bff2d4db9b663130f9e9e3805c42ba46b8017165255c2e55fc135d"
+      "sha256": "7907c114b3bff2d4db9b663130f9e9e3805c42ba46b8017165255c2e55fc135d",
+      "requires": {
+        "tier": "account",
+        "env": [
+          "DATASIFT_EMAIL",
+          "DATASIFT_PASSWORD"
+        ],
+        "accounts": [
+          "DataSift"
+        ],
+        "cost": "Included with DataSift",
+        "fallback": "no-api-playbook#presets-by-hand"
+      }
     },
     {
       "name": "team-hiring",
@@ -552,7 +779,14 @@
       "file_count": 5,
       "bytes": 28005,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/team-hiring.skill",
-      "sha256": "ef1fc8b7c3461ecddfb7abde09b08e2b4f4593132810cb39c5c3feea0747ad21"
+      "sha256": "ef1fc8b7c3461ecddfb7abde09b08e2b4f4593132810cb39c5c3feea0747ad21",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     },
     {
       "name": "text-touch-builder",
@@ -570,7 +804,14 @@
       "file_count": 3,
       "bytes": 30795,
       "download": "https://raw.githubusercontent.com/DataSift-Ty-Personal/SiftStack/main/dist/text-touch-builder.skill",
-      "sha256": "ee627d292a0a2e4a03de07413bf91311e6db8f7365717097a221918acf8c7ea8"
+      "sha256": "ee627d292a0a2e4a03de07413bf91311e6db8f7365717097a221918acf8c7ea8",
+      "requires": {
+        "tier": "none",
+        "fallback": null,
+        "env": [],
+        "accounts": [],
+        "cost": "Free"
+      }
     }
   ]
 }

--- a/tools/build_skills.py
+++ b/tools/build_skills.py
@@ -51,6 +51,91 @@ SUPERSEDED = {
     "deep-prospecting-v4": "deep-prospecting-v5",
 }
 
+# What each package needs before it can actually run, and what to do instead
+# when you do not have it. This is the difference between a library someone
+# installs and a library someone uses: a skill that silently needs a paid key
+# fails on first contact and the person concludes the whole thing is broken.
+#
+# tier:      none    nothing to configure, works on install
+#            account your own login for a service you already pay for
+#            api     a third-party API key, usually metered
+# env:       environment variables the scripts read
+# accounts:  logins rather than keys
+# cost:      what it actually costs, so nobody is surprised by a bill
+# fallback:  the no-API route. Either a sibling skill that does the same job
+#            by browser or by hand, or a named section of the no-API playbook.
+REQUIRES = {
+    # --- tier none: knowledge and generation, no credentials at all ---------
+    "rehab-estimator": dict(tier="none", fallback=None,
+                            note="Ships the locked Knox material list. Other markets use the cheat sheet."),
+    "team-hiring": dict(tier="none", fallback=None),
+    "first-market-county-data": dict(tier="none", fallback=None,
+                                     note="Tells you where to pull county data. The pulling is manual by design."),
+    "playbook-creator": dict(tier="none", fallback=None),
+    "probate-property-finder": dict(tier="none", fallback=None,
+                                    note="Uses free county tax portals and people-search sites."),
+    "text-touch-builder": dict(tier="none", fallback=None),
+    "real-estate-comping": dict(tier="none", fallback=None,
+                                note="This IS the no-key comping route: manual Zillow, Redfin and Realtor pulls."),
+    "buyer-prospector": dict(tier="none", fallback=None,
+                             note="Ships its own nationwide buyer data. Entity research is browser-driven."),
+    "candidate-intake": dict(tier="none", accounts=["Google", "Claude in Chrome"], fallback=None,
+                             note="Runs entirely through the Chrome extension. No API keys."),
+    "deep-prospecting": dict(tier="none", fallback=None, note="Superseded. Manual research method."),
+    "sift-operations": dict(tier="none", fallback=None),
+
+    # --- tier account: your own login for something you already pay for ----
+    "sift-market-research": dict(tier="account", env=["DATASIFT_EMAIL", "DATASIFT_PASSWORD"],
+                                 accounts=["DataSift"], cost="Included with DataSift",
+                                 fallback="no-api-playbook#market-research",
+                                 note="Browser automation of Market Finder. Your login, not an API key."),
+    "sequential-presets": dict(tier="account", env=["DATASIFT_EMAIL", "DATASIFT_PASSWORD"],
+                               accounts=["DataSift"], cost="Included with DataSift",
+                               fallback="no-api-playbook#presets-by-hand"),
+    "sift-sequences": dict(tier="account", env=["DATASIFT_EMAIL", "DATASIFT_PASSWORD"],
+                           accounts=["DataSift"], cost="Included with DataSift",
+                           fallback="no-api-playbook#sequences-by-hand"),
+    "kpi-engine": dict(tier="account", env=["REISIFT_TOKEN"], accounts=["DataSift"],
+                       cost="Included with DataSift",
+                       fallback="no-api-playbook#kpis-by-hand",
+                       note="Mints its own token from your DataSift login. No internal API access needed."),
+    "cold-call-coach": dict(tier="account", accounts=["SmrtPhone", "OpenRouter or Anthropic"],
+                            cost="About $0.002 per audio minute to transcribe",
+                            fallback="no-api-playbook#coaching-without-a-dialer-api"),
+    "lead-manager-coach": dict(tier="account", accounts=["SmrtPhone", "OpenRouter or Anthropic"],
+                               cost="About $0.002 per audio minute to transcribe",
+                               fallback="no-api-playbook#coaching-without-a-dialer-api"),
+    "closer-coach": dict(tier="account", accounts=["SmrtPhone", "OpenRouter or Anthropic"],
+                         cost="About $0.002 per audio minute to transcribe",
+                         fallback="no-api-playbook#coaching-without-a-dialer-api"),
+
+    # --- tier api: a metered third-party key --------------------------------
+    "comp-package": dict(tier="api", env=["OPENWEBNINJA_API_KEY"],
+                         cost="100 free lookups per month, then metered",
+                         fallback="real-estate-comping",
+                         note="Without the key, real-estate-comping does the same job by browser."),
+    "phone-validator": dict(tier="api", env=["TRESTLE_API_KEY"],
+                            cost="About $0.015 per number",
+                            fallback="no-api-playbook#phone-scoring-without-trestle"),
+    "deep-prospecting-v5": dict(tier="api",
+                                env=["SMARTSKIP_EMAIL", "SMARTSKIP_PASSWORD", "TRESTLE_API_KEY"],
+                                cost="About $0.24 per record end to end",
+                                fallback="no-api-playbook#heir-research-by-hand",
+                                note="Enformion is optional and only needed for LLC and trust owners."),
+    "deep-prospecting-v4": dict(tier="api",
+                                env=["ENFORMION_AP_NAME", "ENFORMION_AP_PASSWORD", "TRESTLE_API_KEY"],
+                                cost="About $1.18 per record", fallback="deep-prospecting-v5",
+                                note="Superseded. v5 is roughly 5x cheaper and finds more."),
+    "caller-reputation-monitor": dict(tier="api", env=["TELNYX_API_KEY", "TELNYX_ENTERPRISE_ID"],
+                                      accounts=["Telnyx"], cost="Included with a Telnyx account",
+                                      fallback="no-api-playbook#spam-flag-checks-by-hand"),
+    "deal-analyzer": dict(tier="api", env=["OPENWEBNINJA_API_KEY"],
+                          cost="100 free lookups per month, then metered",
+                          fallback="real-estate-comping",
+                          note="Comping stage only. Rehab and offer math need no key."),
+}
+
+
 # Category drives grouping in the README, the manifest, and the install UI.
 CATEGORY = {
     "sift-market-research": "Market Intelligence",
@@ -352,7 +437,21 @@ def manifest() -> dict:
             }
             if src.name in SUPERSEDED:
                 entry["superseded_by"] = SUPERSEDED[src.name]
+
+            req = dict(REQUIRES.get(src.name, {"tier": "unknown"}))
+            req.setdefault("env", [])
+            req.setdefault("accounts", [])
+            req.setdefault("cost", "Free")
+            req.setdefault("fallback", None)
+            entry["requires"] = req
             entries.append(entry)
+
+    unknown = [e["name"] for e in entries if e["requires"]["tier"] == "unknown"]
+    if unknown:
+        raise SystemExit(
+            "These packages have no REQUIRES entry, so the doctor cannot tell "
+            "anyone whether they can run them or what to do instead: "
+            + ", ".join(unknown))
 
     entries.sort(key=lambda e: (e["category"], e["name"]))
     doc = {
@@ -368,6 +467,15 @@ def manifest() -> dict:
             "plugins": sum(1 for e in entries if e["kind"] == "plugin"),
         },
         "categories": sorted({e["category"] for e in entries}),
+        "tiers": {
+            "none": "Works the moment it is installed. No key, no login.",
+            "account": "Needs a login for a service you already pay for.",
+            "api": "Needs a third-party API key, usually metered.",
+        },
+        "tier_counts": {
+            t: sum(1 for e in entries if e["requires"]["tier"] == t and e["status"] == "current")
+            for t in ("none", "account", "api")
+        },
         "skills": entries,
     }
     MANIFEST.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Keep the setup docs honest against the manifest.
+
+The doctor tells someone "you cannot run this, do X instead". If X points at a
+section that does not exist, or at a key nobody documented, the person is
+stranded at exactly the moment they asked for help. These checks make that a
+build failure rather than a support message.
+
+    python tools/check_docs.py
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "skills" / "manifest.json"
+PLAYBOOK = ROOT / "docs" / "setup" / "no-api-playbook.md"
+GETTING = ROOT / "docs" / "setup" / "GETTING-STARTED.md"
+ENV_EXAMPLE = ROOT / ".env.skills.example"
+API_DIR = ROOT / "docs" / "api"
+
+
+def anchors(md: str) -> set[str]:
+    """Every anchor a link can target: explicit <a id> plus GitHub heading slugs."""
+    found = set(re.findall(r'<a\s+id="([^"]+)"', md))
+    for line in md.splitlines():
+        m = re.match(r"^#{1,6}\s+(.*?)\s*$", line)
+        if m:
+            slug = re.sub(r"[^a-z0-9\s-]", "", m.group(1).lower())
+            found.add(re.sub(r"\s+", "-", slug.strip()))
+    return found
+
+
+def main() -> int:
+    problems: list[str] = []
+    doc = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    current = [e for e in doc["skills"] if e["status"] == "current"]
+
+    play = PLAYBOOK.read_text(encoding="utf-8")
+    play_anchors = anchors(play)
+    env_text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    names = {e["name"] for e in doc["skills"]}
+
+    for e in current:
+        req = e["requires"]
+
+        # 1. Every documented env var must appear in the example file, or
+        #    nobody knows it exists.
+        for var in req.get("env", []):
+            if not re.search(rf"^{re.escape(var)}=", env_text, re.M):
+                problems.append(f"{e['name']}: {var} is not in .env.skills.example")
+
+        # 2. Every fallback must resolve: either a real sibling package or a
+        #    real section of the playbook.
+        fb = req.get("fallback")
+        if not fb:
+            continue
+        if "#" in fb:
+            page, _, anchor = fb.partition("#")
+            if page != "no-api-playbook":
+                problems.append(f"{e['name']}: fallback points at unknown page {page!r}")
+            elif anchor not in play_anchors:
+                problems.append(
+                    f"{e['name']}: fallback anchor #{anchor} does not exist in the playbook")
+        elif fb not in names:
+            problems.append(f"{e['name']}: fallback names unknown package {fb!r}")
+
+    # 3. Any skill needing a credential should have somewhere to send people.
+    for e in current:
+        req = e["requires"]
+        if req["tier"] == "api" and not req.get("fallback"):
+            problems.append(f"{e['name']}: tier 'api' with no fallback and no note")
+
+    # 4. Files linked from the API index must exist.
+    api_readme = (API_DIR / "README.md").read_text(encoding="utf-8")
+    for link in re.findall(r"\]\((([a-z0-9-]+)\.md)\)", api_readme):
+        if not (API_DIR / link[0]).is_file():
+            problems.append(f"docs/api/README.md links to missing {link[0]}")
+
+    # 5. No credential-shaped strings in anything we publish as documentation.
+    secret = re.compile(r"(sk-ant-[A-Za-z0-9_-]{20,}|gh[pous]_[A-Za-z0-9]{20,}"
+                        r"|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,})")
+    for p in list((ROOT / "docs").rglob("*.md")) + [ENV_EXAMPLE]:
+        for m in secret.finditer(p.read_text(encoding="utf-8", errors="replace")):
+            problems.append(f"{p.relative_to(ROOT).as_posix()}: possible credential "
+                            f"{m.group(0)[:20]}...")
+
+    # 6. The example env must never carry a filled-in value.
+    for line in env_text.splitlines():
+        if re.match(r"^[A-Z0-9_]+=.+", line.strip()):
+            problems.append(f".env.skills.example has a value set: {line.split('=')[0]}")
+
+    for p in problems:
+        print(f"::error::{p}" if "--ci" in sys.argv else f"PROBLEM {p}")
+    print(f"checked {len(current)} current packages, "
+          f"{len(play_anchors)} playbook anchors; {len(problems)} problem(s)")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Two gaps. Someone installing the library had no way to find out what they could actually run, and discovered a missing key by watching a skill fail partway through real work. And the API contracts that cost days to establish lived only in CLAUDE.md.

**Nine of the 22 skills need nothing.** That was already true and nothing said so, which is the part that mattered: people assumed the whole library was gated behind keys they did not have.

## `install.py --doctor`

Three groups: works right now, needs you signed in somewhere, needs a credential. Every blocked skill prints its no-API alternative on the same line. Sends no requests, spends nothing, never prints a credential value.

Backed by a `requires` block per package in the manifest (tier, env vars, real cost, fallback). The manifest build **refuses to build** if a package is missing one, because a doctor that is silent about a skill is worse than no doctor.

## The no-API path

`docs/setup/no-api-playbook.md`: comping by browser, heir research off obituaries and free people-search, KPIs off a CSV export, coaching off any dialer's recordings, presets and sequences built by hand from definitions the skills already carry. Explicit about the three things that genuinely have no free substitute.

## API contracts

`docs/api/`, seven files, written from what the services do rather than what they document. Three failure patterns recur across all of them and are named as a class in the index: the silent parameter that returns 200 and ignores your filter, the empty success that means out-of-credit rather than no-results, and the moved contract that keeps billing for a call nothing reads any more.

## Self-enforcing

`tools/check_docs.py` fails the build if a fallback points at a section that does not exist, if a documented env var is missing from the example, if the example ever carries a real value, if an index link breaks, or if anything credential-shaped lands in docs. CI also runs the doctor with every credential stripped, since that is the state the first person to run it is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)