### PR TITLE
Turn the post-walkthrough into one offer workbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,26 @@ The team committed to the Master Material List as THE material source. Knox pric
 - **rehab-estimator.skill + deal-analyzer.plugin** now ship `data/master_material_list_37914.csv` with the doctrine: locked list is the material source for the vast majority of items on Knox deals (off-list only for an outstanding random issue, flagged), cheat sheet keeps labor + non-Knox markets, never multiply locked material prices. The skill's `material_specs` JSON contract is now wired (the Material Specs sheet renderer always existed but was never fed). deal-analyzer's bundled `skills/rehab-estimator/` was EMPTY despite instructing Claude to read 5 files from it; it now carries the full 8-file skill. Both zips rebuilt with forward-slash entry names (Compress-Archive backslash paths are non-portable).
 - Re-lock cadence: re-pull before each project cycle if desired, but re-lock (an explicit, dated, git-diffable act) only when the PM re-approves the list.
 
+## The Offer Sheet: the default post-walkthrough deliverable (build 1.0.49, 2026-08-28)
+
+`src/offer_sheet.py` is THE deliverable after a walkthrough. It replaces the 8-tab post-walkthrough workbook: **one file, five tabs, Offer in front**, wholesale by default, answering exactly one question: **OFFER TO SELLER**. `--offer-only` renders just the front page.
+
+Tabs: **Offer** (the answer) | **The House** (walk condition, seller and probate intel, priced flags, gates) | **Repair Detail** | **Comps** | **Buyers**. Repair Detail, Comps and Buyers are the post_walkthrough builders REUSED as-is; The House condenses the old Overview and Repair Logic into one. Exit Strats is gone (the Offer page supersedes it and four lanes was the confusion Ty rejected), Active-Pending and Outreach are folded away.
+
+**`_hydrate()` is load-bearing.** The reused builders read `pack["sold"]` as live `MarketListing` objects, plus `finished` and an `exits["inputs"]` band; a saved pack carries comps SERIALIZED as `sold_comps`. Without the revive the Comps tab renders empty and reads like a thin market rather than a wiring bug. The buyers band is synthesized from the offer math, which is a truer target than the old exit spread.
+
+```bash
+python src/offer_sheet.py --pack output/<deal>_pack.json --walk walk_<deal>.json                           --out "<Address>_Offer.xlsx"
+```
+
+**Layout is the Fortune Builders "Deal Analyzer for Flips"** (the real file is `output/Copy of The Repair Estimator.xlsx`): paired left/right blocks under banded headers, a percent column beside every dollar column, and inputs INLINE on the same page. The three mortgage tranches are dropped, because financing is a lender-package concern and not an offer concern. Formatting helpers (`_band`, `_row`, `_kv`, `_para`, `_polish`, the INPUT/CALC/TOTAL palette) are IMPORTED from `lender_package.py`, never copied.
+
+**The math is live Excel formulas off defined names**, so one blue cell moves the whole page: `BuyerMax = RulePct * ARV - Rehab`, `OfferToSeller = BuyerMax - Fee`. Rule defaults 70%, fee $15,000 (Ty runs a flat $10-15K assignment fee, per the exit-analysis rule). The "if we buy and rehab it ourselves" block carries net profit, ROI on total cost, purchase-plus-rehab ROI and annualized cash on cash, and it is deliberately subordinate to the offer, not a competing option. Comps (5 lines) and gates (4) are condensed onto the page rather than dropped: an ARV with no visible support is unauditable.
+
+**THE STALE PACK TRAP, hit twice on one deal.** A `--save-pack` JSON is a snapshot and does NOT track later edits. On 1342 Grainger the pack still carried the original four-scenario rehab totals AND the original $481,000 engine ARV after both had been corrected, so a naive re-render produced a workbook three revisions out of date. Rules: recompute rehab via `build_rehab_matrix(subject, walk)` and NEVER read `pack["rehab"]["totals"]`; an explicit CLI `--arv` / `--as-is` WINS over the pack; and write corrections back into the pack so it stops being a landmine.
+
+**Verify by recalculating, not by reading.** The `formulas` package loads the saved xlsx and computes it the way Excel would; assert the offer figure and assert zero formula errors, then flip `RulePct` to 0.75 and confirm the offer, buyer profit and every ROI move together. **Column widths must be set AFTER `_polish`**: `_autofit` sizes off the longest string per column and the full-width paragraphs live in column A, which blew the page to 221 width units and scrolled sideways. Fixed widths total 135 and paragraph rows are re-heighted against the width the text actually gets.
+
 ## The Lender Package (build 1.0.44, 2026-08)
 
 An 8-piece set handed to a private money lender to fund ONE named property. The team hand-edited every template on 2026-08-16 and those edits are the spec; the originals live in `Lender Docs Templates-*.zip`.

--- a/docs/walkthrough-to-offer.md
+++ b/docs/walkthrough-to-offer.md
@@ -1,0 +1,223 @@
+# Walkthrough to offer
+
+How a folder of walk videos becomes one number you can say out loud to a seller.
+
+Worked end to end on **1342 Grainger Ave, Knoxville TN 37917** on 2026-08-27, which
+is the example used throughout. That run produced an offer of **$93,920**.
+
+The agent-executable twin of this document is `sops/walkthrough-to-offer.sop.md`,
+served over MCP as `/agent-sops:walkthrough-to-offer`.
+
+---
+
+## The chain
+
+```
+walk videos  ->  frames  ->  condition
+county card  ->  subject facts (beds, baths, sqft, year)
+drawn map    ->  polygon  ->  comps  ->  ARV
+comp listings ->  finish recipe  ->  ONE rehab number
+                                        |
+                                        v
+                         percent-of-ARV rule  ->  OFFER
+```
+
+Five tabs come out: **Offer**, **The House**, **Repair Detail**, **Comps**, **Buyers**.
+The Offer page is the deliverable. The other four exist so the offer is auditable.
+
+---
+
+## 1. Frames, not narration
+
+```bash
+ffprobe -v error -show_entries format=duration -show_entries stream=codec_type <video>
+ffmpeg -v error -i <video> -vf "fps=1/2,scale=900:-1" -q:v 4 frames/i_%03d.jpg
+ffmpeg -v error -i <still>.HEIC -map 0:v:0 -frames:v 1 -q:v 3 still.jpg
+```
+
+Roughly 190 frames for 6 minutes of video. Read them in batches.
+
+**Transcribe the audio only if there is speech worth having.** On Grainger both videos
+had audio, so they were transcribed for about two cents, and both were ambient
+conversation with the seller rather than scoping narration. The interior transcript
+produced nothing. Two facts did survive, and both mattered: a comment about a "second
+unit back here" (the attached rear wing, resolved from frames) and confirmation that
+the AC unit runs.
+
+**The frames are the evidence.** Zoom into anything ambiguous rather than guessing:
+
+```bash
+ffmpeg -v error -ss 48 -i <video> -vf "crop=760:1080:200:0" -frames:v 1 -q:v 2 zoom.jpg
+```
+
+That is how the hallway debris on Grainger was identified as a failed wall cavity
+rather than a ceiling collapse.
+
+## 2. The county card wins
+
+Query the parcel, then the assessor card:
+
+```
+https://knox-tn.mygovonline.com/api/v2/parcels/<query>?detailLevel=public&start=0&length=25
+https://propertyinfo.knoxcountytn.gov/Datalets/Datalet.aspx?mode=residential&UseSearch=no&pin=<PARID>
+```
+
+Grainger came back 4 bed / 1 full bath / 0 half, 1,332 sf (888 main plus 444 upper
+story finished), built 1920, exterior wall code 04, quality 55 GOOD. Zillow agreed on
+the headline numbers.
+
+**Watch the fixture count.** The card recorded one full bath and **six total
+fixtures**, and the frames showed a toilet and sink upstairs that the county does not
+count. That uncounted plumbing is what made a legal half bath cheap, and it is a
+common find in old houses.
+
+## 3. Draw the boundary, then prove it
+
+A pocket is bounded by roads, highways and rail. Use `--polygon`, never `--bbox`.
+Trace the drawn map into `[lat, lon]` pairs, then **print every street that landed
+inside** and compare against the map.
+
+On Grainger the polygon was right and it was doing real work: it excluded the Old
+North Knoxville Victorian corridor on Luttrell St that sold **$690,000 to $1,350,000**,
+which sits south of I-40 and outside the line. Inside it were 27 sold comps on
+Grainger, Hoitt, Leonard, Overton, Cecil, N 4th through N 6th, Brown and Thompson.
+
+## 4. Judge the ARV, do not accept it
+
+```bash
+python src/post_walkthrough.py --address "1342 Grainger Ave" --city Knoxville --zip 37917 \
+    --beds 4 --baths 1 --sqft 1332 --year-built 1920 --months 24 \
+    --polygon output/1342_grainger_polygon.json \
+    --walkthrough walk_1342_grainger.json \
+    --save-pack output/1342_grainger_pack.json
+```
+
+`--months` is the POOL, not the preference. `tight_arv` prefers 12 months and widens
+only when that leaves under three comps, so passing a narrow pool starves the widener.
+
+**The engine returned $481,000 and it was wrong.** Its same-bed clamp left three
+renovated three-bed sales, and two of them were 1,600 to 1,660 sf homes on Leonard Pl
+and Luttrell St, the two most expensive streets inside the boundary. The sanity check
+killed it: 1318 Grainger, two doors down, sold at $274/sf.
+
+Releasing the bed clamp to size peers gave 11 comps at $286/sf. Then the bath split:
+
+| | median $/sf | at 1,332 sf |
+|---|---|---|
+| 1 bath (n=4) | $276 | $367,000 |
+| 2+ bath (n=7) | $299 | $398,000 |
+
+An 8.6% bath premium, measured rather than assumed. The final figure was set at
+**$348,000 ($261/sf)**, the bottom of the peer band, which sits under even the one-bath
+read.
+
+Boundary variants were tested at 0.20, 0.25 and 0.30 miles and a trimmed polygon. All
+hit the same two or three comps, which proved the constraint was the bed clamp and not
+the boundary. Test the boundary anyway; that is how you find out which it is.
+
+## 5. Let the comps pick the finish
+
+Pull `property-details-address` for the closest peers and read the descriptions.
+
+- **1410 Cecil, $276/sf:** "original unpainted trim, doors, **windows**, and hardwood
+  floors, all preserved." Kitchen remodeled, bathroom "stylishly refreshed."
+- **1910 Luttrell, $292/sf:** "original clawfoot tub," original hardwood, Victorian
+  doors.
+- **1108 Overton, $299/sf, top of the band:** a **1.5 bath** with laminate floors and a
+  granite kitchen.
+
+That pocket pays for preserved character plus a new kitchen. It does not pay for a gut
+with LVP and vinyl windows. So the scope became a renovation with `gut: false`, the
+Windows and HVAC categories dropped, and the Overton comp is the whole reason the
+target stayed 4 bed / 1.5 bath instead of losing a bedroom.
+
+Write the evidence into `comp_finish_basis`, quoting the comps by name and price.
+
+## 6. One rehab number
+
+Set `single_scenario` in the walk file. Never emit the four-scenario matrix.
+
+```json
+"single_scenario": {
+  "key": "reno", "label": "Comp-Match Reno (4 bed / 1.5 bath)",
+  "tier": 2, "scope": "full", "gut": false,
+  "beds": 4, "baths": 1.5, "drop": ["Windows", "HVAC"]
+}
+```
+
+Grainger landed at **$134,680**, $101/sf, 7.8 weeks. Walk flags were $69,400 of it,
+52%, which is the honest story of that house: porch, siding, foundation, water damage
+and estate cleanout are condition, not finish.
+
+## 7. Render and verify
+
+```bash
+python src/offer_sheet.py --pack output/1342_grainger_pack.json \
+    --walk walk_1342_grainger.json --out "1342_Grainger_Ave_Offer.xlsx"
+```
+
+Then compute it the way Excel would, rather than reading it:
+
+```python
+import formulas
+sol = formulas.ExcelModel().loads("1342_Grainger_Ave_Offer.xlsx").finish().calculate()
+```
+
+Assert the offer and assert zero formula errors. Then flip `RulePct` from 0.70 to 0.75
+and confirm the offer, the buyer profit and every return move together. On Grainger
+that moved the offer from $93,920 to $111,320 and dropped buyer profit from $79,376 to
+$61,976, which proves the page is live.
+
+## 8. Say the assignment math out loud
+
+```
+Buyer's maximum   0.70 x $348,000 - $134,680  =  $108,920
+Our fee                                          $ 15,000
+OFFER TO SELLER                                  $ 93,920
+```
+
+To clear a $15,000 fee, buy at $93,900 or under. To clear $25,000, buy at $83,900 or
+under.
+
+**Say it when the numbers do not work.** The engine's own wholesale lane suggested
+assigning at $182,000 for a $67,000 fee, derived from the as-is comp band. A flipper
+carrying a $134,680 rehab cannot pay that; the gap is $73,000. The as-is band reflects
+investor buys on houses needing far less work. Report the conflict rather than
+shipping the flattering number.
+
+---
+
+## The four traps, all of which fail silently
+
+**1. Flag scenario keys.** `single_scenario` sets the key to `reno`. A flag still
+carrying `["mid","gut_t2","gut_t3"]` is dropped with no warning. On Grainger that would
+have deleted **$19,900** of real work: foundation repointing, basement moisture, the
+carport and final clean. **Set every flag's `scenarios` to `[]`.**
+
+**2. The stale pack.** A `--save-pack` JSON is a snapshot and does not track later
+edits. Grainger's pack held both the old four-scenario rehab totals and the old
+$481,000 ARV long after both were corrected, and a naive re-render produced a $187,020
+offer. Recompute rehab from the walk file, let explicit CLI values beat the pack, and
+write corrections back into the pack.
+
+**3. The bed clamp.** `tight_arv` matches bed count exactly. In a thin pocket that can
+leave three comps sitting on the two most expensive streets. Inspect which comps built
+the number before believing it.
+
+**4. Autofit and column widths.** `_autofit` sizes off the longest string per column,
+and full-width paragraphs live in column A, which blew the offer page to 221 width
+units and scrolled sideways. **Set widths after `_polish`, then re-height the wrapped
+rows** against the width they actually get.
+
+## Smaller things that cost time
+
+- Excel holds an exclusive lock. If the workbook is open, `wb.save()` raises
+  `PermissionError`; the renderer writes a `_PENDING_` copy instead.
+- `output/`, `*.xlsx` and `walk_*.json` are gitignored. Deal artifacts stay local by
+  design; only code and docs are committed.
+- The locked material list is pinned to zip 37914. It is Knox-local and correct for any
+  Knox deal, but say so rather than letting someone discover it.
+- The CRM is worth reading before you trust the walk. On Grainger it revealed the owner
+  had died, probate was never opened, the house was vacant, and the seller had already
+  named the defect ("plumbing came apart in the bathroom"). That corrected two
+  conclusions drawn from the video alone.

--- a/sops/walkthrough-to-offer.sop.md
+++ b/sops/walkthrough-to-offer.sop.md
@@ -1,0 +1,139 @@
+# Walkthrough To Offer
+
+## Overview
+
+This SOP turns walkthrough media for a single property into one Excel workbook whose front page answers one question: what do we offer the seller. It reads the walk videos frame by frame to scope condition, pulls sold comps inside a drawn boundary to set a conservative ARV, reads the comps' own listing remarks to decide the finish level, prices one rehab number against that finish, and renders a wholesale offer built on the percent-of-ARV rule. Use it the hour after walking a house, before any price is discussed with the seller.
+
+## Parameters
+
+- **property_address** (required): Street address of the subject, e.g. "1342 Grainger Ave"
+- **media_folder** (required): Folder holding the walkthrough videos and stills
+- **zip_code** (required): Subject ZIP, used for the comp pull
+- **city** (optional, default: "Knoxville"): Subject city
+- **boundary_polygon** (optional): Path to a JSON file of [lat, lon] pairs, or a hand-drawn map to trace. Without one the comp set is the whole ZIP, which is almost never right
+- **rule_pct** (optional, default: "0.70"): Percent-of-ARV rule that sets the buyer's maximum
+- **assignment_fee** (optional, default: "15000"): Our flat wholesale fee
+- **arv_override** (optional): Force the ARV instead of taking the engine's figure
+
+**Constraints for parameter acquisition:**
+- If all required parameters are already provided, You MUST proceed to the Steps
+- If any required parameters are missing, You MUST ask for them before proceeding
+- When asking for parameters, You MUST request all parameters in a single prompt
+- When asking for parameters, You MUST use the exact parameter names as defined
+
+## Steps
+
+### 1. Extract frames from the walk media
+
+Probe every video for duration and audio, then cut frames at 2 second intervals with ffmpeg (`fps=1/2,scale=900:-1`) into a scratch folder. Convert any HEIC stills with `-map 0:v:0 -frames:v 1`.
+
+**Constraints:**
+- You MUST check for an audio track and transcribe it only if speech is present, because walk videos are frequently silent or carry only ambient conversation with the seller, and a transcript of ambient talk yields nothing worth paying for
+- You MUST treat the frames as the primary evidence, because narration cannot be relied on
+- You MUST write frames to a scratch directory, NOT the repo, since they are large and disposable
+- Artifact: a frame directory, roughly 190 frames for 6 minutes of video
+
+### 2. Read every frame and record the condition
+
+Look at the frames in batches and write down what is actually visible: roof, siding, foundation, mechanicals, kitchen, baths, flooring, wall and ceiling finishes, and any water damage or structural failure.
+
+**Constraints:**
+- You MUST record only what a frame or a document shows, because this scope becomes a real offer on a real house
+- You MUST NOT infer a cost, a measurement or a condition that no frame proves, because someone will act on this number and an invented defect is as expensive as a missed one
+- You SHOULD zoom into any ambiguous area with a cropped ffmpeg extract at the relevant timestamp rather than guessing
+- Artifact: a written condition list keyed to frame numbers
+
+### 3. Pin the subject facts from the county, not the aggregator
+
+Query the county tax API for the parcel, then the assessor card for beds, baths, living area, year built and exterior wall code. Cross-check against Zillow and the CRM record.
+
+**Constraints:**
+- You MUST treat the county card as authoritative over Zillow and over the CRM, because aggregators get bed and bath counts wrong and the bed count moves the ARV by six figures
+- You MUST note any plumbing fixture count that exceeds what the recorded bath count implies, because uncounted upstairs plumbing is common in old houses and it makes an added bath far cheaper
+- Artifact: a subject facts block including parcel id
+
+### 4. Draw and validate the comp boundary
+
+Turn the drawn map into a polygon of [lat, lon] pairs and test it against a sold cache before trusting it.
+
+**Constraints:**
+- You MUST use a polygon rather than a bounding box, because a pocket is bounded by roads, highways and rail, not by a rectangle
+- You MUST print every street and address that fell inside and compare it against the drawn map before accepting any ARV
+- You MUST test two or three boundaries and report how the ARV moves, because a boundary that bleeds into a stronger sub-market silently inflates the number
+- Artifact: `output/<deal>_polygon.json`
+
+### 5. Pull comps and set a conservative ARV
+
+Run `src/post_walkthrough.py` with the polygon to pull sold comps and save a pack. Then judge the ARV rather than accepting it.
+
+**Constraints:**
+- You MUST inspect which comps the ARV was built on and reject the figure if a thin same-bed set puts it on the market's most expensive streets
+- You SHOULD widen from the same-bed clamp to size peers when the same-bed set has fewer than five comps, and You MUST say so in the basis string when you do
+- You MUST anchor the ARV against the nearest sale on the subject's own street, because a pocket median can be a different street's number
+- You MUST measure the bath gap across the peer set and state it, since a one-bath house does not earn a two-bath price
+- Artifact: `output/<deal>_pack.json` and a written ARV basis
+
+### 6. Read the comps' listing remarks to set the finish
+
+Pull `property-details-address` for the closest peer comps and read the descriptions and resoFacts.
+
+**Constraints:**
+- You MUST scope the renovation to the finishes the comps actually sold with, because a finish tier chosen off a menu is an opinion while a finish read off the comps is evidence
+- You MUST NOT budget a full gut when the comps sell on preserved original character, since that spends money the market does not pay back
+- You MUST record the evidence in the walk file's `comp_finish_basis` field, quoting named comps and their prices
+- Artifact: a finish recipe traceable to named comps
+
+### 7. Write the walkthrough JSON with exactly one scenario
+
+Start from `python src/post_walkthrough.py --walkthrough-template`, then fill in condition, priced flags, gates and a single `single_scenario` block.
+
+**Constraints:**
+- You MUST set `single_scenario` and You MUST NOT emit the four-scenario matrix, because the operator wants one rehab number rather than a menu
+- You MUST set every flag's `scenarios` to `[]` when using `single_scenario`, because a flag carrying a non-matching key such as `["mid","gut_t2"]` is DROPPED SILENTLY and can delete tens of thousands of dollars of real work
+- You MUST give any cost awaiting a signed bid a realistic value with `"placeholder": true` rather than a blank or a zero, so the total stays a true number
+- You MUST record anything that can prevent a closing, such as an unopened probate, in `gates`
+- Artifact: `walk_<deal>.json`
+
+### 8. Render the workbook
+
+Run `src/offer_sheet.py` with the pack and the walk file to build the five tab workbook: Offer, The House, Repair Detail, Comps, Buyers.
+
+**Constraints:**
+- You MUST pass `--walk` explicitly and You MUST NOT rely on the copy inside the pack, because a saved pack is a snapshot that does not track later edits and has already served stale rehab totals and a stale ARV
+- You MUST pass `--arv` when the engine figure was overridden, since an explicit value beats the pack
+- Artifact: `<Address>_Offer.xlsx`
+
+### 9. Verify by recalculating, not by reading
+
+Load the saved workbook with the `formulas` package and compute it the way Excel would.
+
+**Constraints:**
+- You MUST assert the offer figure and assert zero formula errors, because a workbook that opens is not a workbook that is correct
+- You MUST change the rule percentage and confirm the offer, the buyer profit and every return move together, which proves the page is live rather than static
+- You MUST confirm no tab scrolls horizontally and that no em or en dash appears anywhere
+- You MUST state the assignment math out loud: the buyer maximum, the offer, and the buy price needed to clear the fee. If the numbers do not support a deal, You MUST say so plainly rather than tuning inputs until they do
+- Artifact: a verification result naming the computed offer
+
+## Examples
+
+**1342 Grainger Ave, Knoxville TN 37917 (the worked example).** A 1920 four bed, one bath, 1,332 sf estate property, vacant, probate not yet opened. Two videos totalling 6:14 with no usable narration, reviewed as 187 frames. The county card corrected Zillow. The drawn polygon held 27 sold comps, and the engine's same-bed ARV of $481,000 was rejected because two of its three comps sat on the pocket's premium streets; the size-peer read with the bath gap measured landed at $348,000. Listing remarks on the comps showed preserved original trim, doors and windows, so the scope became a renovation rather than a gut, at $134,680. Result: buyer maximum $108,920, assignment fee $15,000, **offer to seller $93,920**.
+
+```bash
+python src/post_walkthrough.py --address "1342 Grainger Ave" --city Knoxville --zip 37917     --beds 4 --baths 1 --sqft 1332 --year-built 1920 --months 24     --polygon output/1342_grainger_polygon.json --walkthrough walk_1342_grainger.json     --save-pack output/1342_grainger_pack.json
+
+python src/offer_sheet.py --pack output/1342_grainger_pack.json     --walk walk_1342_grainger.json --out "1342_Grainger_Ave_Offer.xlsx"
+```
+
+## Troubleshooting
+
+**The rehab number looks wrong or matches an older run.** The pack is stale. Recompute from the walk file and pass `--walk` explicitly; never read the serialized totals.
+
+**A cost you wrote in the walk file is missing from the workbook.** A flag carries a `scenarios` list that does not include the `single_scenario` key. Set every flag to `[]`.
+
+**The ARV is far above the nearest sale on the subject's street.** The same-bed clamp has landed on a thin set concentrated on better streets. Widen to size peers and say so in the basis.
+
+**The Comps tab is empty.** The comps were not revived from the pack into live objects. This is a wiring fault, not a thin market.
+
+**`PermissionError` on save.** The workbook is open in Excel, which holds an exclusive lock. The renderer writes a `_PENDING_` copy instead; close Excel and rename it.
+
+**A tab scrolls sideways.** Column widths were set before autofit rather than after. Autofit sizes off the longest string in a column and the full-width paragraphs live in column A.

--- a/src/offer_sheet.py
+++ b/src/offer_sheet.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""One-page wholesale offer sheet, laid out like the Fortune Builders analyzer.
+
+This is the default deliverable after a walkthrough (Ty, 2026-08-27). It answers
+exactly one question, OFFER TO SELLER, and it answers it on ONE tab.
+
+    "I'm really just looking for a very simple offer price estimation, and let's
+     not do a bunch of different options. As a default, let's just look to
+     wholesale this and build out an offer price structure in that way. Similar
+     to how the Fortune Builders rehab estimator breaks down profit and ROI."
+
+Shape is lifted from `output/Copy of The Repair Estimator.xlsx`, tab "Deal
+Analyzer for Flips": paired left and right blocks under banded headers, a
+percent column beside every dollar column, inputs INLINE on the same page, and
+a net profit and ROI snapshot. The three mortgage tranches are dropped because
+they are a lender-package concern, not an offer concern.
+
+Every result is a live Excel formula off a workbook defined name, so changing a
+blue cell moves the offer, the buyer's profit and every ROI together.
+
+Usage:
+    python src/offer_sheet.py --pack output/1342_grainger_pack.json \
+                              --walk walk_1342_grainger.json \
+                              --out "1342_Grainger_Ave_Offer.xlsx"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font
+from openpyxl.utils import get_column_letter
+from openpyxl.workbook.defined_name import DefinedName
+
+from lender_package import (BOX, CALC_FILL, GREEN, GREY, INPUT_FILL, MONEY, MULT,
+                            NAVY, NUM, PCT0, PCT1, RED, TOTAL_FILL, _band, _kv,
+                            _para, _polish, _row, _title)
+import post_walkthrough as pw
+from post_walkthrough import MarketListing, build_rehab_matrix, rng
+
+logger = logging.getLogger(__name__)
+
+# Defaults are the operator's, not the model's. Every one is a blue cell.
+DEFAULT_RULE = 0.70          # the classic maximum-allowable-offer haircut
+DEFAULT_FEE = 15_000         # Ty runs a flat $10-15K assignment fee
+DEFAULT_HOLD = 6             # months, for the buy-it-ourselves block only
+DEFAULT_INSURANCE = 225      # vacant dwelling, monthly
+DEFAULT_UTILITIES = 200      # monthly while held
+DEFAULT_ESCROW_BUY = 900
+DEFAULT_TITLE_PCT = 0.0077
+DEFAULT_ESCROW_SELL = 900
+DEFAULT_REALTOR_PCT = 0.054
+DEFAULT_TRANSFER_PCT = 0.0037   # TN transfer tax plus recording
+MAX_COMPS = 5
+MAX_GATES = 4
+
+
+def _num(v, default=0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _ba(v) -> str:
+    """1.0 renders as 1, 1.5 stays 1.5."""
+    f = _num(v)
+    return str(int(f)) if f == int(f) else str(f)
+
+
+def _revive(rows: list) -> list:
+    out = []
+    for c in rows or []:
+        c = dict(c)
+        c.pop("raw", None)
+        try:
+            out.append(MarketListing(**c))
+        except TypeError:
+            continue
+    return out
+
+
+def _hydrate(pack: dict, walk: dict, args) -> None:
+    """Give the reused post_walkthrough builders exactly what they read.
+
+    They want live MarketListing objects on pack["sold"], a recomputed rehab,
+    and an exits["inputs"] band. A saved pack carries the comps SERIALIZED as
+    pack["sold_comps"], so without this the Comps tab renders empty and looks
+    like a thin market rather than a wiring bug.
+    """
+    pack["sold"] = _revive(pack.get("sold_comps"))
+    pack["active"] = _revive(pack.get("active_comps"))
+    pack["walk"] = walk
+    pack["rehab"] = build_rehab_matrix(pack["subject"], walk)   # never trust the saved one
+    pack.setdefault("buckets", {})
+    pack.setdefault("deeds", {})
+    pack.setdefault("buyers", [])
+    pack.setdefault("max_buyers", 25)
+    pack.setdefault("arv_comp_ids", list((pack.get("arv") or {}).get("comp_ids") or []))
+
+    target = walk.get("target_config") or {}
+    finished = dict(pack["subject"])
+    finished["beds"] = int(target.get("beds") or finished.get("beds") or 3)
+    finished["baths"] = float(target.get("baths") or finished.get("baths") or 1.0)
+    pack["finished"] = finished
+
+    # sheet_buyers ranks buyers against THIS deal's band. The band is now the
+    # offer band, which is a truer target than the old exit engine's spread.
+    arv = _num(args.arv) or _num(((pack.get("arv") or {}).get("base") or {}).get("arv"))
+    rehab_total = _num(next(iter((pack["rehab"].get("totals") or {"reno": 0}).values())))
+    as_is = _num(args.as_is) or _num(pack.get("as_is"))
+    offer = round(_num(args.rule) * arv - rehab_total - _num(args.fee))
+    assign = offer + _num(args.fee)
+    pack["exits"] = {"inputs": {
+        "shell": bool(walk.get("unfinanceable")),
+        "contract": rng(offer, confident=True), "contract_point": offer,
+        "assign": rng(assign, confident=True), "assign_point": assign,
+        "as_is": rng(as_is, confident=True), "as_is_point": as_is,
+    }}
+
+
+def sheet_offer(wb: Workbook, pack: dict, walk: dict, args) -> None:
+    subject = pack["subject"]
+    lead = pack.get("lead") or {}
+    arv_block = pack.get("arv") or {}
+    base = arv_block.get("base") or {}
+    tight = arv_block.get("tight") or {}
+
+    # THE TRAP: pack["rehab"]["totals"] can be stale (it is serialized at the
+    # original run and survives later walk edits). Always recompute.
+    rehab = build_rehab_matrix(subject, walk)
+    rehab_total = _num((rehab.get("totals") or {}).get(
+        next(iter(rehab.get("totals") or {"reno": 0}))))
+    scen = (rehab.get("scenarios") or [{}])[0]
+    scen_label = scen.get("label") or "Comp-Match Reno"
+
+    # An explicit CLI figure WINS over the pack. A saved pack is a snapshot and
+    # goes stale the moment the walk or the ARV is revised, which has already
+    # bitten this deal twice (the rehab totals and the ARV both).
+    arv = _num(args.arv) or _num(base.get("arv"))
+    as_is = _num(args.as_is) or _num(pack.get("as_is"))
+    sqft = int(_num(subject.get("sqft"), 0))
+
+    # Annual property tax: Zillow publishes a rate, the county Values tab 500s.
+    # This is a seed for a blue cell, never presented as a fact.
+    tax_rate = _num(args.tax_rate, 0.0039)
+    tax_annual = round(_num(lead.get("estimated_value")) * tax_rate) or 1100
+
+    ws = wb.create_sheet("Offer")
+    names: dict[str, str] = {}
+    wide_rows: list[int] = []
+
+    def name(nm: str, col: int, row: int) -> None:
+        names[nm] = f"'Offer'!${get_column_letter(col)}${row}"
+
+    addr = subject.get("full_address") or subject.get("address") or ""
+    _title(ws, "Wholesale offer analysis", addr,
+           "Blue cells are yours to change. Grey cells calculate off them. "
+           "Change one blue cell and the offer, the buyer's profit and every "
+           "return move with it.")
+
+    # ── property header ────────────────────────────────────────────────
+    r = 5
+    r = _band(ws, r, "Property", col=1, span=7)
+    _kv(ws, r, "Address", addr, span=2)
+    _row(ws, r, 5, "Beds / baths",
+         val=f"{subject.get('beds','')} / {_ba(subject.get('baths'))}", val_fmt=None)
+    r += 1
+    _kv(ws, r, "Square footage", sqft, fmt=NUM)
+    _row(ws, r, 5, "Year built", val=subject.get("year_built", ""), val_fmt=NUM)
+    r += 1
+    _kv(ws, r, "County / parcel",
+        f"{subject.get('county','')} / {str(subject.get('parcel_id','')).upper()}")
+    _row(ws, r, 5, "Prepared", val=args.prepared or date.today().isoformat(),
+         val_fmt=None)
+    r += 2
+
+    # ── values and pricing | holding costs ─────────────────────────────
+    top = r
+    r = _band(ws, r, "Property values and pricing", col=1, span=3)
+    r = _row(ws, r, 1, "After repair value (ARV)", val=arv, fill=INPUT_FILL)
+    name("ARV", 3, r - 1)
+    r = _row(ws, r, 1, "Current as-is value", val=as_is, fill=INPUT_FILL)
+    name("AsIs", 3, r - 1)
+    r = _row(ws, r, 1, f"Estimated repair costs: {scen_label}",
+             val=rehab_total, fill=INPUT_FILL)
+    name("Rehab", 3, r - 1)
+    r = _row(ws, r, 1, "Rule of thumb (percent of ARV)", val=_num(args.rule),
+             val_fmt=PCT0, fill=INPUT_FILL)
+    name("RulePct", 3, r - 1)
+    r = _row(ws, r, 1, "Hold time, months (if we keep it)", val=args.hold,
+             val_fmt=NUM, fill=INPUT_FILL)
+    name("HoldMonths", 3, r - 1)
+    r = _row(ws, r, 1, "Repair cost per square foot",
+             val=f"=IFERROR(Rehab/{max(sqft,1)},0)", val_fmt=MONEY, fill=CALC_FILL)
+    left_end = r
+
+    r = top
+    r = _band(ws, r, "Holding costs (monthly)", col=5, span=3,
+              headers=("Annually", "Monthly"))
+    r = _row(ws, r, 5, "Property taxes", pct=tax_annual, val=f"=ROUND({tax_annual}/12,0)",
+             pct_fmt=MONEY, fill=CALC_FILL, pct_fill=INPUT_FILL)
+    name("TaxAnnual", 6, r - 1)
+    r = _row(ws, r, 5, "Insurance (vacant dwelling)", val=args.insurance,
+             fill=INPUT_FILL)
+    name("Insurance", 7, r - 1)
+    r = _row(ws, r, 5, "Utilities", val=args.utilities, fill=INPUT_FILL)
+    name("Utilities", 7, r - 1)
+    r = _row(ws, r, 5, "Total monthly holding:",
+             val="=ROUND(TaxAnnual/12,0)+Insurance+Utilities",
+             bold=True, fill=TOTAL_FILL)
+    name("HoldMonthly", 7, r - 1)
+    r = _row(ws, r, 5, "Total over the hold",
+             val="=HoldMonthly*HoldMonths", fill=CALC_FILL)
+    name("HoldTotal", 7, r - 1)
+    r = max(r, left_end) + 1
+
+    # ── buying | selling transaction costs ─────────────────────────────
+    top = r
+    r = _band(ws, r, "Buying costs", col=1, span=3, headers=("Pct of purch", "Total"))
+    r = _row(ws, r, 1, "Escrow / attorney fees", val=args.escrow_buy, fill=INPUT_FILL)
+    name("EscrowBuy", 3, r - 1)
+    r = _row(ws, r, 1, "Title insurance / search", pct=_num(args.title_pct),
+             val="=ROUND(OfferToSeller*TitlePct,0)", fill=CALC_FILL,
+             pct_fill=INPUT_FILL)
+    name("TitlePct", 2, r - 1)
+    r = _row(ws, r, 1, "Total buying costs:", val="=EscrowBuy+ROUND(OfferToSeller*TitlePct,0)",
+             bold=True, fill=TOTAL_FILL)
+    name("BuyCosts", 3, r - 1)
+    left_end = r
+
+    r = top
+    r = _band(ws, r, "Selling costs", col=5, span=3, headers=("Pct of ARV", "Total"))
+    r = _row(ws, r, 5, "Escrow / attorney, recording", val=args.escrow_sell,
+             fill=INPUT_FILL)
+    name("EscrowSell", 7, r - 1)
+    r = _row(ws, r, 5, "Realtor fee", pct=_num(args.realtor_pct),
+             val="=ROUND(ARV*RealtorPct,0)", fill=CALC_FILL, pct_fill=INPUT_FILL)
+    name("RealtorPct", 6, r - 1)
+    r = _row(ws, r, 5, "Transfer tax and conveyance", pct=_num(args.transfer_pct),
+             val="=ROUND(ARV*TransferPct,0)", fill=CALC_FILL, pct_fill=INPUT_FILL)
+    name("TransferPct", 6, r - 1)
+    r = _row(ws, r, 5, "Total selling costs:",
+             val="=EscrowSell+ROUND(ARV*RealtorPct,0)+ROUND(ARV*TransferPct,0)",
+             bold=True, fill=TOTAL_FILL)
+    name("SellCosts", 7, r - 1)
+    r = max(r, left_end) + 1
+
+    # ── THE OFFER ──────────────────────────────────────────────────────
+    r = _band(ws, r, "THE OFFER", col=1, span=7)
+    r = _row(ws, r, 1, "Buyer's maximum  (rule of thumb x ARV, less repairs)",
+             val="=ROUND(RulePct*ARV-Rehab,0)", fill=CALC_FILL)
+    name("BuyerMax", 3, r - 1)
+    r = _row(ws, r, 1, "Our assignment fee", val=args.fee, fill=INPUT_FILL)
+    name("Fee", 3, r - 1)
+
+    c = ws.cell(row=r, column=1, value="OFFER TO SELLER")
+    c.font = Font(bold=True, size=13, color=NAVY)
+    v = ws.cell(row=r, column=3, value="=BuyerMax-Fee")
+    v.number_format = MONEY
+    v.font = Font(bold=True, size=13, color=GREEN)
+    v.fill = TOTAL_FILL
+    v.border = BOX
+    name("OfferToSeller", 3, r)
+    ws.cell(row=r, column=5,
+            value="This is the number. Everything above it is an input, "
+                  "everything below it is a consequence.").font = Font(size=9, color=GREY)
+    ws.row_dimensions[r].height = 22
+    r += 1
+    r = _row(ws, r, 1, "What the buyer pays us at closing",
+             val="=OfferToSeller+Fee", fill=CALC_FILL)
+    name("BuyerPays", 3, r - 1)
+    r = _row(ws, r, 1, "Offer as a percent of ARV",
+             val="=IFERROR(OfferToSeller/ARV,0)", val_fmt=PCT1, fill=CALC_FILL)
+    r = _row(ws, r, 1, "Offer against the as-is comp band",
+             val="=IFERROR(OfferToSeller/AsIs,0)", val_fmt=PCT1, fill=CALC_FILL,
+             note="Under 100% means we are buying below what as-is houses trade for here")
+    r += 1
+
+    # ── if we wholesale it (the default) ───────────────────────────────
+    top = r
+    r = _band(ws, r, "If we wholesale it   (the default)", col=1, span=3)
+    r = _row(ws, r, 1, "Our fee", val="=Fee", bold=True, fill=TOTAL_FILL)
+    r = _row(ws, r, 1, "Capital we put up", val=0, fill=CALC_FILL)
+    r = _row(ws, r, 1, "Rehab risk we carry", val="none", val_fmt=None, fill=CALC_FILL)
+    left_end = r
+
+    r = top
+    r = _band(ws, r, "What the buyer gets at that price", col=5, span=3)
+    r = _row(ws, r, 5, "Buyer's net profit",
+             val="=ARV-BuyerPays-Rehab-HoldTotal-SellCosts-EscrowBuy",
+             bold=True, fill=TOTAL_FILL)
+    name("BuyerProfit", 7, r - 1)
+    r = _row(ws, r, 5, "Buyer's return on total cost",
+             val="=IFERROR(BuyerProfit/(BuyerPays+Rehab+HoldTotal+SellCosts+EscrowBuy),0)",
+             val_fmt=PCT1, fill=CALC_FILL)
+    r = _row(ws, r, 5, "Buyer's all-in against ARV",
+             val="=IFERROR((BuyerPays+Rehab)/ARV,0)", val_fmt=PCT1, fill=CALC_FILL)
+    r = max(r, left_end) + 1
+
+    # ── if we buy and rehab it ourselves ───────────────────────────────
+    r = _band(ws, r, "If we buy and rehab it ourselves", col=1, span=7)
+    top = r
+    r = _row(ws, r, 1, "Estimated NET PROFIT",
+             val="=ARV-OfferToSeller-Rehab-HoldTotal-BuyCosts-SellCosts",
+             bold=True, fill=TOTAL_FILL)
+    name("NetProfit", 3, r - 1)
+    r = _row(ws, r, 1, "Committed capital",
+             val="=OfferToSeller+Rehab+HoldTotal+BuyCosts", fill=CALC_FILL)
+    name("Capital", 3, r - 1)
+    r = _row(ws, r, 1, "Purchase and repair per square foot",
+             val=f"=IFERROR((OfferToSeller+Rehab)/{max(sqft,1)},0)", fill=CALC_FILL)
+    left_end = r
+
+    r = top
+    r = _row(ws, r, 5, "Return on total cost (ROI)",
+             val="=IFERROR(NetProfit/Capital,0)", val_fmt=PCT1, bold=True,
+             fill=TOTAL_FILL)
+    r = _row(ws, r, 5, "Purchase plus rehab ROI",
+             val="=IFERROR(NetProfit/(OfferToSeller+Rehab),0)", val_fmt=PCT1,
+             fill=CALC_FILL)
+    r = _row(ws, r, 5, "Annualized cash on cash",
+             val="=IFERROR(NetProfit/Capital*12/MAX(HoldMonths,1),0)",
+             val_fmt=PCT1, fill=CALC_FILL)
+    r = max(r, left_end) + 1
+
+    # ── ARV basis ──────────────────────────────────────────────────────
+    comp_ids = set(arv_block.get("comp_ids") or [])
+    comps = [c for c in _revive(pack.get("sold_comps"))
+             if str(c.zpid) in comp_ids and c.sqft]
+    comps.sort(key=lambda c: abs((c.sqft or 0) - sqft))
+    r = _band(ws, r, "What the ARV stands on", col=1, span=7)
+    hdr = ["Comp", "Bed/bath", "Sqft", "Sold", "$/sf", "Date", ""]
+    for j, h in enumerate(hdr, 1):
+        cell = ws.cell(row=r, column=j, value=h)
+        cell.font = Font(bold=True, size=9, color="FFFFFF")
+        cell.fill = _band_fill()
+        cell.border = BOX
+    r += 1
+    for c in comps[:MAX_COMPS]:
+        for j, v in enumerate([c.address, f"{c.beds}/{c.baths}", c.sqft,
+                               c.price, round(c.ppsf), c.sold_date], 1):
+            cell = ws.cell(row=r, column=j, value=v)
+            cell.font = Font(size=9.5)
+            cell.border = BOX
+            cell.fill = CALC_FILL
+            if j == 3:
+                cell.number_format = NUM
+            if j in (4, 5):
+                cell.number_format = MONEY
+        r += 1
+    basis = tight.get("basis") or ""
+    if basis:
+        wide_rows.append(r)
+        r = _para(ws, r, basis, size=8.5, color=GREY, span=7)
+    r += 1
+
+    # ── before you offer ───────────────────────────────────────────────
+    gates = [g for g in (walk.get("gates") or [])][:MAX_GATES]
+    if gates:
+        r = _band(ws, r, "Before you offer", col=1, span=7)
+        for g in gates:
+            wide_rows.append(r)
+            r = _para(ws, r, g, size=9, color=RED, span=7)
+
+    for nm, ref in names.items():
+        wb.defined_names[nm] = DefinedName(nm, attr_text=ref)
+
+    _polish(ws)
+    # _autofit sizes off the longest thing in each column, and the full-width
+    # paragraphs (the ARV basis, the gates) live in column A, so it blows A, D
+    # and E out to 54 and the page scrolls sideways. Fixed widths, then row
+    # heights recomputed against the width the text actually gets.
+    _finalize(ws, wide_rows)
+    ws.freeze_panes = "A5"
+
+
+def sheet_house(wb: Workbook, pack: dict, walk: dict) -> None:
+    """The house and the seller: what the walk found, and who we are buying from.
+
+    Condenses the old Overview and Repair Logic tabs into one. Overview carried
+    the Sift lead, Repair Logic carried the flags and gates, and reading a deal
+    meant bouncing between them.
+    """
+    subject, lead = pack["subject"], (pack.get("lead") or {})
+    ws = wb.create_sheet("The House")
+    wide: list[int] = []
+
+    _title(ws, "The house and the seller",
+           subject.get("full_address") or subject.get("address", ""),
+           f"From the walk on {walk.get('walk_date', '')}. "
+           f"{walk.get('media', '')}".strip())
+
+    r = 5
+    r = _band(ws, r, "Who we are buying from", col=1, span=7)
+    for label, val in (
+        ("Owner of record", (lead.get("owner_name") or "")
+         + (" [DECEASED on record]" if lead.get("owner_deceased") else "")),
+        ("Mailing", lead.get("mailing", "")),
+        ("Sift record", lead.get("url", "")),
+        ("Status / SIFTline", f"{lead.get('status','')} | "
+         f"{', '.join(lead.get('cards') or []) or 'not on a board'}"),
+        ("Tags", ", ".join(str(t) for t in (lead.get("tags") or [])) or "(none)"),
+        ("Last contact", f"{lead.get('last_contact','')} "
+         f"({lead.get('last_contact_type','')})".strip()),
+    ):
+        if val:
+            r = _kv(ws, r, label, val, span=6, fill=CALC_FILL)
+    for key in ("owner", "motivation", "acquired"):
+        if walk.get(key):
+            wide.append(r)
+            ws.cell(row=r, column=1, value=key.capitalize()).font = Font(bold=True, size=9)
+            r = _para(ws, r, walk[key], size=9, col=2, span=6)
+    r += 1
+
+    r = _band(ws, r, "What the walk found", col=1, span=7)
+    for key, label in (("layout", "Layout"), ("distress", "Condition"),
+                       ("note", "Note"), ("comp_finish_basis", "Finish set by the comps")):
+        if walk.get(key):
+            ws.cell(row=r, column=1, value=label).font = Font(bold=True, size=9)
+            wide.append(r)
+            r = _para(ws, r, walk[key], size=8.5, col=2, span=6)
+    r += 1
+
+    open_items = walk.get("still_open") or []
+    if open_items:
+        r = _band(ws, r, "Still open", col=1, span=7)
+        for i in open_items:
+            ws.cell(row=r, column=1, value=i.get("item", "")).font = Font(bold=True, size=9)
+            wide.append(r)
+            r = _para(ws, r, i.get("detail", ""), size=8.5, col=2, span=6)
+        r += 1
+
+    flags = [f for f in (walk.get("flags") or []) if _num(f.get("cost"))]
+    if flags:
+        r = _band(ws, r, "Priced line items from the walk", col=1, span=7,
+                  headers=("", "Cost"))
+        for f in flags:
+            ph = bool(f.get("placeholder"))
+            c = ws.cell(row=r, column=1, value=f.get("item", ""))
+            c.font = Font(size=9, color=RED if ph else "000000")
+            v = ws.cell(row=r, column=3, value=_num(f.get("cost")))
+            v.number_format = MONEY
+            v.fill = CALC_FILL
+            v.border = BOX
+            v.font = Font(size=9, color=RED if ph else "000000")
+            ws.cell(row=r, column=5, value=f.get("note", "")[:150]).font = Font(
+                size=8, color=GREY)
+            r += 1
+        t = ws.cell(row=r, column=1, value="Total priced from the walk")
+        t.font = Font(bold=True, size=10)
+        v = ws.cell(row=r, column=3, value=sum(_num(f.get("cost")) for f in flags))
+        v.number_format = MONEY
+        v.font = Font(bold=True, size=10)
+        v.fill = TOTAL_FILL
+        v.border = BOX
+        r += 1
+        wide.append(r)
+        r = _para(ws, r, "Figures in red are PLACEHOLDERS pending a signed bid. They "
+                         "are realistic assumed costs so the total stays a true "
+                         "number, never a blank.", size=8, color=RED, span=7)
+        r += 1
+
+    gates = walk.get("gates") or []
+    if gates:
+        r = _band(ws, r, "Before you offer", col=1, span=7)
+        for g in gates:
+            wide.append(r)
+            r = _para(ws, r, g, size=9, color=RED, span=7)
+
+    _polish(ws)
+    _finalize(ws, wide, first_col=26.0)
+
+
+def build_workbook(pack: dict, walk: dict, args, out: str) -> str:
+    """Offer page in front, backup tabs behind it, each with one job."""
+    wb = Workbook()
+    wb.remove(wb.active)
+    sheet_offer(wb, pack, walk, args)
+    if not args.offer_only:
+        sheet_house(wb, pack, walk)
+        for fn, title in ((pw.sheet_repair_numbers, "Repair Detail"),
+                          (pw.sheet_comps, "Comps"),
+                          (pw.sheet_buyers, "Buyers")):
+            try:
+                before = set(wb.sheetnames)
+                fn(wb, pack)
+                new = [s for s in wb.sheetnames if s not in before]
+                if new:
+                    s = wb[new[0]]
+                    s.title = title
+                    # The reused grids bring their own widths (a 17-column comp
+                    # table needs them). Give them the same print setup and a
+                    # frozen header so they read like the rest of the book.
+                    s.sheet_view.zoomScale = 100
+                    s.page_setup.orientation = "landscape"
+                    s.page_setup.fitToWidth = 1
+                    s.page_setup.fitToHeight = 0
+                    s.sheet_properties.pageSetUpPr.fitToPage = True
+                    s.freeze_panes = "A3"
+            except Exception as exc:      # a thin section is not a failed run
+                logger.warning("%s sheet skipped: %s", title, exc)
+    return _save(wb, out)
+
+
+def _save(wb: Workbook, out: str) -> str:
+    """Excel holds an exclusive lock on an open workbook, so write then swap."""
+    dest = Path(out)
+    tmp = dest.with_name(f"_PENDING_{dest.name}")
+    wb.save(tmp)
+    try:
+        tmp.replace(dest)
+        return str(dest)
+    except PermissionError:
+        logger.warning("%s is open in Excel and could not be replaced. "
+                       "The new workbook is at %s: close Excel and rename it.",
+                       dest.name, tmp.name)
+        return str(tmp)
+
+
+# Label | pct | value  x2, with a narrow gutter between the two halves.
+COL_WIDTHS = [44.0, 12.0, 15.0, 3.0, 34.0, 12.0, 15.0]
+
+
+def _finalize(ws, wide_rows: list[int], first_col: float | None = None) -> None:
+    """Lock column widths and re-height only the rows that wrap full width."""
+    widths = list(COL_WIDTHS)
+    if first_col:
+        widths[0] = first_col
+    for i, w in enumerate(widths, 1):
+        ws.column_dimensions[get_column_letter(i)].width = w
+    span = sum(widths)
+    for row in wide_rows:
+        cell = ws.cell(row=row, column=1)
+        text = str(cell.value or "")
+        if not text:                      # paragraph rendered in column B
+            text = str(ws.cell(row=row, column=2).value or "")
+            cell = ws.cell(row=row, column=2)
+        size = cell.font.size or 10
+        # ~1 width unit per character at 11pt; scale for the smaller face.
+        per_line = max(int(span * (11.0 / size)), 20)
+        lines = max(1, -(-len(text) // per_line))
+        ws.row_dimensions[row].height = max(14.0, lines * (size + 3.2) + 4)
+
+
+def _band_fill():
+    from openpyxl.styles import PatternFill
+    return PatternFill("solid", fgColor="44506B")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pack", required=True, help="post_walkthrough --save-pack JSON")
+    ap.add_argument("--walk", help="walkthrough JSON (defaults to the one in the pack)")
+    ap.add_argument("--out", help="output .xlsx")
+    ap.add_argument("--rule", type=float, default=DEFAULT_RULE)
+    ap.add_argument("--fee", type=float, default=DEFAULT_FEE)
+    ap.add_argument("--hold", type=int, default=DEFAULT_HOLD)
+    ap.add_argument("--arv", type=float, default=0)
+    ap.add_argument("--as-is", dest="as_is", type=float, default=0)
+    ap.add_argument("--tax-rate", type=float, default=0.0039)
+    ap.add_argument("--insurance", type=float, default=DEFAULT_INSURANCE)
+    ap.add_argument("--utilities", type=float, default=DEFAULT_UTILITIES)
+    ap.add_argument("--escrow-buy", type=float, default=DEFAULT_ESCROW_BUY)
+    ap.add_argument("--title-pct", type=float, default=DEFAULT_TITLE_PCT)
+    ap.add_argument("--escrow-sell", type=float, default=DEFAULT_ESCROW_SELL)
+    ap.add_argument("--realtor-pct", type=float, default=DEFAULT_REALTOR_PCT)
+    ap.add_argument("--transfer-pct", type=float, default=DEFAULT_TRANSFER_PCT)
+    ap.add_argument("--prepared", default="")
+    ap.add_argument("--offer-only", action="store_true",
+                    help="Render just the Offer page, no backup tabs")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        format="%(levelname)s %(message)s")
+
+    pack = json.loads(Path(args.pack).read_text(encoding="utf8"))
+    walk = (json.loads(Path(args.walk).read_text(encoding="utf8"))
+            if args.walk else (pack.get("walk") or {}))
+    _hydrate(pack, walk, args)
+    subject = pack["subject"]
+    safe = "".join(ch for ch in (subject.get("address") or "Offer")
+                   if ch.isalnum() or ch in " -")[:44].strip().replace(" ", "_")
+    out = args.out or f"{safe}_Offer.xlsx"
+    out = build_workbook(pack, walk, args, out)
+
+    rehab = build_rehab_matrix(subject, walk)
+    rt = _num(next(iter((rehab.get("totals") or {"reno": 0}).values())))
+    arv = _num(args.arv) or _num((pack.get("arv", {}).get("base") or {}).get("arv"))
+    buyer_max = round(args.rule * arv - rt)
+    print(f"ARV ${arv:,.0f} | rehab ${rt:,.0f} | rule {args.rule:.0%} | fee ${args.fee:,.0f}")
+    print(f"Buyer's maximum ${buyer_max:,.0f}  ->  OFFER TO SELLER "
+          f"${buyer_max - args.fee:,.0f}")
+    print(f"workbook: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Replaces the 8-tab post-walkthrough workbook with one file whose front page answers the only question an acquisitions call needs: **what do we offer**.

## What changed

`src/offer_sheet.py` renders five tabs:

| Tab | |
|---|---|
| **Offer** | The Fortune Builders "Deal Analyzer for Flips" page condensed to a wholesale decision |
| **The House** | Walk condition, seller and probate intel, priced flags, gates |
| **Repair Detail** | One scenario, line by line |
| **Comps** | What the ARV stands on |
| **Buyers** | Ranked against this deal's band |

The Offer page keeps the Estimator conventions: paired left and right blocks under banded headers, a percent column beside every dollar column, inputs inline, and every result a live formula off a defined name. Change the rule percentage and the offer, the buyer's profit and every return move together. The three mortgage tranches are dropped as a lender-package concern, not an offer concern.

Repair Detail, Comps and Buyers are the existing `post_walkthrough` builders reused untouched. Formatting comes from `lender_package` rather than a second copy of it. No existing module is modified.

`_hydrate()` is what makes the reuse work: a saved pack carries its comps serialized, so without reviving them into `MarketListing` objects the Comps tab renders empty and reads like a thin market rather than a wiring bug.

## Replication

- `sops/walkthrough-to-offer.sop.md`, served over MCP as `/agent-sops:walkthrough-to-offer` (passes `validate_sop.py`)
- `docs/walkthrough-to-offer.md`, the runbook with the 1342 Grainger worked example

## Verified

Recalculated with the `formulas` package rather than read: offer computes to $93,920 with zero formula errors, and flipping the rule from 70% to 75% moves the offer to $111,320 and buyer profit to $61,976. Five tabs populate, `--offer-only` still yields one, zero em or en dashes.

## The traps, documented because they all fail silently

1. `single_scenario` renames the scenario key, so a flag carrying the old keys is dropped without a word. On 1342 Grainger that would have deleted $19,900 of real work.
2. A saved pack is a snapshot and does not track later edits. It served both a stale rehab total and a stale ARV on this deal.
3. `tight_arv` matches bed count exactly, which in a thin pocket can leave three comps on the two most expensive streets.
4. `_autofit` sizes off the longest string per column, and full-width paragraphs live in column A, which scrolled the page sideways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)